### PR TITLE
fix(repo): a Windows clone failed the test suite before you wrote any code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Line endings.
+#
+# WHY THIS FILE EXISTS. Several fixtures are compared BYTE FOR BYTE against a string the
+# code builds with '\n' — `station_identity.rs` and `watch_identity.rs` read
+# `tests/fixtures/*.json` and `assert_eq!` the whole document. With no .gitattributes, a
+# clone on Windows under Git's default `core.autocrlf=true` checks those fixtures out as
+# CRLF, so the comparison cannot pass and a PRISTINE clone fails its own test suite. The
+# failure message reads "Do not rebaseline: find what changed", which sends a new
+# contributor hunting a bug that is not there. Development on Linux never sees it.
+#
+# So: normalise text to LF in the working tree on every platform.
+* text=auto eol=lf
+
+# EXCEPTIONS — these carry CRLF deliberately and must survive byte for byte.
+# `-text` disables eol translation in both directions, so the bytes on disk are the bytes
+# in the object store.
+#
+# Third-party data shipped as published. cty.dat is AD1C's country file and the .tle is a
+# captured Celestrak payload; both are line-oriented formats consumed verbatim, and the
+# TLE is a test fixture whose bytes are the point.
+crates/propagation/data/cty.dat            -text
+crates/propagation/tests/fixtures/*.tle    -text
+
+# Vendored hamlib licence texts, bundled as Tauri resources. Licence files are reproduced
+# as received — rewriting their line endings edits third-party legal text.
+src-tauri/resources/hamlib/*.txt           -text
+
+# Binary assets: never eol-translated, never diffed as text.
+*.png     binary
+*.webp    binary
+*.wav     binary
+*.bin     binary
+*.ico     binary
+*.icns    binary
+*.onnx    binary


### PR DESCRIPTION
## Summary

**A clone of this repo on Windows fails `cargo test --workspace` before the contributor edits anything.**

`station_identity.rs` and `watch_identity.rs` compare a generated document byte for byte against `tests/fixtures/*.json`, building their side of the comparison with `'\n'`. With no `.gitattributes`, a clone under Git's default `core.autocrlf=true` checks those fixtures out as CRLF, so the assertion cannot pass. The message it fails with is:

> station-wide snapshot changed. … Do not rebaseline: find what changed.

— which sends a new contributor hunting a bug that does not exist. Development on Linux never sees it, but WINDOWS.md and CONTRIBUTING.md both invite native Windows work, so every Windows contributor meets this first.

This pins the working tree to LF on every platform, with explicit `-text` exceptions for content that carries CRLF deliberately and must survive byte for byte:

| Path | Why it is excepted |
|---|---|
| `crates/propagation/data/cty.dat` | AD1C's country file, shipped as published |
| `crates/propagation/tests/fixtures/*.tle` | A captured Celestrak payload — a fixture whose exact bytes are the point |
| `src-tauri/resources/hamlib/*.txt` | Vendored hamlib licence texts; rewriting a third-party licence's line endings edits legal text reproduced as received |

I found those three by scanning for CRLF in tracked content rather than assuming, because a blanket `eol=lf` would have quietly rewritten all six of those files.

## Linked issue

n/a — found while setting up a Windows environment to work on #10.

## Checklist

- [x] `cargo test` passes on the workspace (headless modem + engine + net + TempoDeep round-trips).
- [x] `cargo clippy --all-targets` is clean (no new warnings). — no code change.
- [ ] UI touched? — **no.**
- [x] Docs updated where relevant. — the rationale lives in `.gitattributes` itself, which is where someone will look.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## Validation

- **Validated against:** Simulation / tooling only. No waveform, timing, TX or hardware path is involved — this changes checkout behaviour and nothing else.
- **Notes:**

  Cloned this repo twice with `core.autocrlf=true` (Git's Windows default), once at `main` and once at this branch:

  | | byte-exact fixture | vendored hamlib licence |
  |---|---|---|
  | `main` today | **105 CRLF** → suite red | 339 CRLF |
  | this branch | **0 CRLF** → suite green | **339 CRLF, unchanged** |

  I hit the failure for real on a fresh Windows clone at the start of this work; `station_state_is_byte_identical_to_golden` failed, and passed after renormalising the tree to LF.

  **`git add --renormalize .` against this file stages nothing but `.gitattributes` itself.** Every other tracked text file is already LF in the object store, so this rewrites no committed bytes — it changes only what lands in a working tree on checkout. That is the check that matters here, and it is the reason the three exceptions above are explicit rather than left to `text=auto`'s binary heuristic.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
