### PR TITLE
fix(deb): the package installed cleanly and then could not open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Nexus (formerly Tempo) are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The Linux .deb installed cleanly and then would not start.** The package named Hamlib, WebKit
+  and GTK as its dependencies but never mentioned the Fortran runtime or single-precision FFTW
+  that the modem is linked against — so `apt` reported success, the menu entry appeared, and the
+  binary then died on `libgfortran.so.5: cannot open shared object file` the moment you clicked
+  it. Nothing in the install said anything was missing, because as far as `dpkg` was concerned
+  nothing was. It only ever worked by luck: on a machine that happened to have both libraries
+  already, for some other reason. The package now declares `libgfortran5` and `libfftw3-single3`,
+  so `apt` installs them with Nexus — and on a system that genuinely cannot supply them, the
+  install refuses up front instead of handing you an application that cannot open.
+
 ## [1.0.1] — 2026-08-05
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,7 +80,7 @@
     },
     "linux": {
       "deb": {
-        "depends": ["libhamlib-utils"]
+        "depends": ["libhamlib-utils", "libgfortran5", "libfftw3-single3"]
       }
     }
   },


### PR DESCRIPTION
## Summary

**The Linux .deb installs cleanly and then cannot open.** It declares `libhamlib-utils` (plus the `libwebkit2gtk-4.1-0` / `libgtk-3-0` Tauri adds), but the binary's `NEEDED` list also carries **`libgfortran.so.5`** and **`libfftw3f.so.3`** — the Fortran runtime and single-precision FFTW `libtempo` links against. Neither is declared.

So `dpkg` reports success, the menu entry appears, and clicking it does nothing visible. From a terminal:

```
error while loading shared libraries: libgfortran.so.5
```

Nothing in the install warned, because as far as `dpkg` was concerned nothing was missing. It only ever worked by luck — on machines that already had both libraries for some other reason.

**This is not Mint-specific.** It reproduces on Ubuntu 24.04, the build host's own distro, whenever those libraries are absent.

This adds the two packages to `bundle.linux.deb.depends`, so `apt` pulls them in — and on a system that genuinely cannot supply them, the install refuses up front instead of handing the operator an application that cannot open.

## Linked issue

Refs #3

That report has a **second, independent cause this PR does not address** — see Validation below. I have deliberately not guessed at it, so this does not close the issue.

## Checklist

- [x] `cargo test` passes on the workspace (headless modem + engine + net + TempoDeep round-trips).
- [x] `cargo clippy --all-targets` is clean (no new warnings). — no code change; this is packaging metadata.
- [ ] UI touched? — **no.**
- [x] Docs updated where relevant. — CHANGELOG entry under `## [Unreleased]`.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## Validation

- **Validated against:** Container reproduction from the **published v1.0.1 .deb**, not a local build. No radio hardware and no on-air operation; this changes packaging metadata only.
- **Notes:**

  On `ubuntu:24.04`, installing the published `Nexus_1.0.1_pc_amd64.deb`:

  ```
  $ dpkg-deb -f Nexus_1.0.1_pc_amd64.deb Depends
  libhamlib-utils, libwebkit2gtk-4.1-0, libgtk-3-0

  $ ldd /usr/bin/Nexus | grep 'not found'
  libgfortran.so.5 => not found
  libfftw3f.so.3 => not found

  $ Nexus
  error while loading shared libraries: libgfortran.so.5
  ```

  After installing `libgfortran5` and `libfftw3-single3` by hand, every library resolves and the app starts (it then fails only at GTK init, correctly, because the container has no display).

  **Package names verified to own those sonames on every distro Nexus ships a .deb for** — `ubuntu:22.04`, `ubuntu:24.04`, `debian:bookworm`, `debian:trixie` — so the arm64 Pi packages are covered by the same two names:

  | soname | package | 22.04 | 24.04 | bookworm | trixie |
  |---|---|---|---|---|---|
  | `libgfortran.so.5` | `libgfortran5` | ✓ | ✓ | ✓ | ✓ |
  | `libfftw3f.so.3` | `libfftw3-single3` | ✓ | ✓ | ✓ | ✓ |

  ### The second cause in #3, which this does NOT fix

  On Ubuntu 22.04 (= Mint 21.3's base), **even with both libraries installed**:

  ```
  /usr/bin/Nexus: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
    distro glibc : 2.35        binary needs : GLIBC_2.39
  ```

  The published binary is built on 24.04 (glibc 2.39); Mint 21.3 is 22.04 (glibc 2.35). No package can satisfy that — it needs either building on an older base or stating the supported floor. That is a release-target decision, so I have left it to you rather than guessing, and this PR only *refs* #3 rather than closing it.

  ### Note on merge order

  The `## [Unreleased]` heading here will conflict textually with #11, which adds the same heading. Both entries are independent bullets; whichever merges second just keeps both.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
