### PR TITLE
fix(macos): declare NSMicrophoneUsageDescription so audio input can be authorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS: RX audio could go permanently silent with no error shown.** The bundle shipped with no
+  `NSMicrophoneUsageDescription` in `Info.plist`, so macOS could never show the audio-input
+  permission prompt at all. Once the OS records a denial for the app's bundle ID, CoreAudio does
+  not surface that as an error — the input stream opens normally and the audio pipeline runs, it
+  just delivers silence, which looked identical to a device-selection or gain problem. Added
+  `src-tauri/Info.plist` with the usage description so macOS can actually ask; anyone hitting this
+  on an existing install also needs `tccutil reset Microphone com.kd9taw.tempo` once to clear the
+  stuck denial before the next launch will prompt again.
+
 ## [1.0.2] — 2026-08-06
 
 

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Nexus decodes received audio from your radio's soundcard interface (FT8/FT4, RTTY, SSTV, CW, and other digital modes) and needs input access to do so.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- The macOS bundle shipped with no `Info.plist` entries at all beyond Tauri's defaults — in particular, no `NSMicrophoneUsageDescription`. Without that key, macOS can never show the microphone permission prompt for the app, period.
- Once TCC has recorded a denial for the bundle ID (`com.kd9taw.tempo`) from any prior attempt — including from before this fix existed — CoreAudio does **not** surface that as an error on subsequent runs. The input stream opens fine, the audio pipeline runs, it just delivers silence. From the operator's side this is indistinguishable from a device-selection or RX-gain problem, which is exactly what it looked like in the bug report this fixes (see linked context: "audio is arriving but it is silent").
- Added `src-tauri/Info.plist` with the usage description string. Tauri's bundler merges a `src-tauri/Info.plist`, if present, into the generated bundle's Info.plist — confirmed by building and checking the merged plist directly.

## Who else this affects

Anyone who already has Nexus installed and previously hit a mic permission dialog (or a silent auto-deny) is likely stuck with a recorded TCC denial that this fix alone won't clear — they need to run this once after updating:

```sh
tccutil reset Microphone com.kd9taw.tempo
```

then relaunch. Might be worth a line in the release notes / Getting Started troubleshooting doc for anyone upgrading from an affected version — happy to add that if useful.

## Test plan

- [x] Built locally (`cargo tauri build --features radio`) and confirmed via `PlistBuddy -c Print Info.plist` that `NSMicrophoneUsageDescription` is present in the bundled app
- [x] Installed on a real station (Yaesu FTX-1 via CAT + USB audio interface), ran `tccutil reset Microphone com.kd9taw.tempo`, relaunched — macOS showed the mic permission dialog for the first time, and RX audio started decoding immediately after Allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)