### PR TITLE
fix: TX Level (Pwr) slider lag and drive curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The TX Level (Pwr) slider lagged several seconds behind what was actually going out, and its
+  useful range was crushed into the bottom of the travel.** Holding Tune while trimming drive
+  against a rig's ALC meter, the slider looked like it was doing nothing and then suddenly
+  jumped: the tune carrier was generated in fixed 40ms chunks regardless of how often the
+  driving loop actually ticked, so the queued backlog grew without bound for as long as Tune
+  was held — audio reaching the rig could run several seconds stale. Separately, the Settings
+  panel's own Tx Power slider only applied its value on release, not while dragging, so it gave
+  no feedback until you let go, unlike the matching cockpit "Pwr" slider. TX drive now tracks
+  both sliders live while dragging. And now that it does: the drive range that actually matters
+  on real hardware — 0 up to just past where ALC engages — turned out to live in only the bottom
+  15-20% of the old linear slider, so both sliders now use a curve that gives that range most of
+  the travel. What a saved drive level means is unchanged either way.
+
 - **FT8 and FT4 were putting a six-character grid square on the air.** A standard FT8 or FT4
   message has room for four characters of locator and no more, so if you had set a six-character
   grid in Settings, your calls to another station carried something the message format cannot hold.

--- a/crates/tempo-audio/src/service.rs
+++ b/crates/tempo-audio/src/service.rs
@@ -11219,7 +11219,14 @@ mod tests {
 
         state
             .step(
-                &engine, &mut backend, &mut rig, &sinks, 0.0, &mut ra, &mut rr, &mut station,
+                &engine,
+                &mut backend,
+                &mut rig,
+                &sinks,
+                0.0,
+                &mut ra,
+                &mut rr,
+                &mut station,
             )
             .unwrap();
         let first_chunk_len = backend.played.len();
@@ -11232,7 +11239,14 @@ mod tests {
         // 40ms, to reproduce the mismatch that overflowed out_ring.
         state
             .step(
-                &engine, &mut backend, &mut rig, &sinks, 20.0, &mut ra, &mut rr, &mut station,
+                &engine,
+                &mut backend,
+                &mut rig,
+                &sinks,
+                20.0,
+                &mut ra,
+                &mut rr,
+                &mut station,
             )
             .unwrap();
         let second_chunk_len = backend.played.len() - first_chunk_len;

--- a/crates/tempo-audio/src/service.rs
+++ b/crates/tempo-audio/src/service.rs
@@ -1742,6 +1742,13 @@ struct RadioLoop {
     tune_was_data: bool,
     tune_phase: f32,
     tune_started_ms: Option<f64>,
+    /// Wall-clock timestamp (ms) the last tune-carrier chunk was generated from, so the NEXT
+    /// chunk can be sized off real elapsed time instead of a fixed constant. Without this,
+    /// `TUNE_CHUNK_MS`-sized chunks queued on a faster tick cadence made `out_ring` grow
+    /// unbounded for as long as Tune was held (confirmed live: past 190,000 queued samples,
+    /// zero drainage). `None` between tune holds and for the first chunk of a new hold, which
+    /// still seeds off `TUNE_CHUNK_MS` before there's an elapsed-time baseline.
+    tune_last_chunk_ms: Option<f64>,
     applied: Transport,
     /// Set when a handoff bailed on the pool lock: step() skips ONE rig_differs rebuild
     /// tick so the handoff (not a fresh spawn racing the monitor's port) wins.
@@ -2068,6 +2075,7 @@ impl RadioLoop {
             tune_was_data: false,
             tune_phase: 0.0,
             tune_started_ms: None,
+            tune_last_chunk_ms: None,
             applied,
             rigctld_proc,
             cat_hold_active: false,
@@ -4984,7 +4992,20 @@ impl RadioLoop {
                 self.tx_until_ms = None; // a tune supersedes any pending slot TX tail
                 self.slot_tx_until_ms = 0.0; // …so there is no slot over left to protect
             }
-            let n = (tempo_fast::SAMPLE_RATE * (TUNE_CHUNK_MS / 1000.0)) as usize;
+            // Size this chunk off real elapsed wall-clock time since the last one, not the
+            // fixed TUNE_CHUNK_MS constant. The driving loop's actual tick period doesn't
+            // match TUNE_CHUNK_MS, and queuing a fixed-duration chunk every tick regardless of
+            // how much real time passed is what let out_ring grow without bound for as long as
+            // Tune was held. Clamped so a stalled tick (e.g. a slow CAT read) can't queue one
+            // huge catch-up burst. TUNE_CHUNK_MS still seeds the FIRST chunk of a hold, before
+            // there's an elapsed-time baseline.
+            let elapsed_ms = self
+                .tune_last_chunk_ms
+                .map(|last| (now - last) as f32)
+                .unwrap_or(TUNE_CHUNK_MS)
+                .clamp(0.0, TUNE_CHUNK_MS * 4.0);
+            self.tune_last_chunk_ms = Some(now);
+            let n = (tempo_fast::SAMPLE_RATE * (elapsed_ms / 1000.0)) as usize;
             let chunk = tune_carrier(
                 TUNE_FREQ_HZ,
                 n,
@@ -5007,6 +5028,7 @@ impl RadioLoop {
             }
             self.tuning_keyed = false;
             self.tune_started_ms = None;
+            self.tune_last_chunk_ms = None;
             self.last_slot = None;
             self.prev_slot_was_tx = false;
         }
@@ -11175,6 +11197,50 @@ mod tests {
         assert!(
             state.last_slot.is_none(),
             "slot decode skipped while tuning"
+        );
+    }
+
+    #[test]
+    fn tune_chunk_pacing_follows_elapsed_time_not_a_fixed_constant() {
+        // Regression test for the out_ring-growth bug: a chunk sized off the fixed
+        // TUNE_CHUNK_MS constant (40ms) every ~20ms driving-loop tick queued audio twice as
+        // fast as it could ever play, so out_ring grew without bound for as long as Tune was
+        // held (confirmed live: past 190,000 queued samples, zero drainage). The SECOND chunk
+        // of a hold must be sized off real elapsed time since the first, not TUNE_CHUNK_MS
+        // again — only the very first chunk of a hold still seeds off the constant, before
+        // there's an elapsed-time baseline.
+        let engine = Arc::new(Mutex::new(Engine::new("W9XYZ", "EN37", 0)));
+        engine.lock().unwrap().set_tune(true);
+        let mut backend = MockBackend::new();
+        let mut rig = Rig::vox();
+        let mut state = loop_state();
+        let (sinks, mut ra, mut rr) = (no_sinks(), mock_reopen_audio(), mock_reopen_rig());
+        let mut station = StationSinks::new();
+
+        state
+            .step(
+                &engine, &mut backend, &mut rig, &sinks, 0.0, &mut ra, &mut rr, &mut station,
+            )
+            .unwrap();
+        let first_chunk_len = backend.played.len();
+        assert_eq!(
+            first_chunk_len, 480,
+            "first chunk of a hold still seeds off TUNE_CHUNK_MS (40ms @ 12kHz)"
+        );
+
+        // The real driving loop ticks every 20ms — simulate that cadence, not TUNE_CHUNK_MS's
+        // 40ms, to reproduce the mismatch that overflowed out_ring.
+        state
+            .step(
+                &engine, &mut backend, &mut rig, &sinks, 20.0, &mut ra, &mut rr, &mut station,
+            )
+            .unwrap();
+        let second_chunk_len = backend.played.len() - first_chunk_len;
+        assert_eq!(
+            second_chunk_len, 240,
+            "second chunk must be sized off the real 20ms elapsed (240 samples @ 12kHz), not \
+             the fixed 40ms TUNE_CHUNK_MS (480 samples) — the bug queued a 480-sample chunk \
+             every 20ms tick, doubling out_ring's backlog every tick with zero drainage"
         );
     }
 

--- a/ui/src/components/CockpitHeader.tsx
+++ b/ui/src/components/CockpitHeader.tsx
@@ -216,13 +216,20 @@ export function CockpitHeader({
               max={power.unit === '%' ? 100 : 1}
               step={power.unit === '%' ? 1 : 0.01}
               // Drive-unit sliders (tx_level, 0-1) use a square-law curve between slider
-              // POSITION and the underlying level: position² -> level, √level -> position. The
-              // real hardware-usable drive range (0 up to just past where ALC engages) sits in
-              // only the bottom ~15-20% of a linear slider, so this spreads that critical
-              // region across most of the travel. The '%' RF-power sliders (Phone/SSTV) are a
-              // different backend value entirely and stay linear. What tx_level itself means is
-              // completely unchanged — only how far the slider travels to reach a given level.
-              value={power.unit === 'drive' ? Math.sqrt(power.value) : power.value}
+              // POSITION and the underlying level: position^2 -> level, sqrt(level) ->
+              // position. The real hardware-usable drive range (0 up to just past where ALC
+              // engages) sits in only the bottom ~15-20% of a linear slider, so this spreads
+              // that critical region across most of the travel. The '%' RF-power sliders
+              // (Phone/SSTV) are a different backend value entirely and stay linear. What
+              // tx_level itself means is completely unchanged - only how far the slider
+              // travels to reach a given level. Rounded to the 0.01 step grid: an unrounded
+              // sqrt() rarely lands on a step boundary, and a step-mismatched range input
+              // value fails HTML5 constraint validation.
+              value={
+                power.unit === 'drive'
+                  ? Math.round(Math.sqrt(power.value) * 100) / 100
+                  : power.value
+              }
               onChange={(e) => {
                 const raw = Number(e.target.value)
                 power.onChange(power.unit === 'drive' ? raw ** 2 : raw)

--- a/ui/src/components/CockpitHeader.tsx
+++ b/ui/src/components/CockpitHeader.tsx
@@ -215,8 +215,18 @@ export function CockpitHeader({
               min={0}
               max={power.unit === '%' ? 100 : 1}
               step={power.unit === '%' ? 1 : 0.01}
-              value={power.value}
-              onChange={(e) => power.onChange(Number(e.target.value))}
+              // Drive-unit sliders (tx_level, 0-1) use a square-law curve between slider
+              // POSITION and the underlying level: position² -> level, √level -> position. The
+              // real hardware-usable drive range (0 up to just past where ALC engages) sits in
+              // only the bottom ~15-20% of a linear slider, so this spreads that critical
+              // region across most of the travel. The '%' RF-power sliders (Phone/SSTV) are a
+              // different backend value entirely and stay linear. What tx_level itself means is
+              // completely unchanged — only how far the slider travels to reach a given level.
+              value={power.unit === 'drive' ? Math.sqrt(power.value) : power.value}
+              onChange={(e) => {
+                const raw = Number(e.target.value)
+                power.onChange(power.unit === 'drive' ? raw ** 2 : raw)
+              }}
               onPointerDown={power.onPointerDown}
               onPointerUp={power.onPointerUp}
               aria-label={power.label ?? 'Power'}

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -842,8 +842,15 @@ export function SettingsPanel({
 
   // Apply TX drive (Pwr) to the LIVE radio, the SAME value as the cockpit "Pwr" slider —
   // set_tx_level persists + updates the snapshot, so the cockpit reflects it immediately.
-  // Commit on release (not per drag tick) to avoid disk-thrash.
-  const applyTxLevelLive = (value: number) => {
+  // Throttled to ~16 Hz while dragging (not gated entirely on release): set_tx_level writes
+  // the whole settings.json to disk on every call, so applying on every onChange tick would
+  // trade release-only jank for disk-thrash on every drag pixel. `force` (pointerUp/keyUp)
+  // bypasses the throttle window so the final settled value is never silently dropped by it.
+  const txLevelThrottleRef = useRef(0)
+  const applyTxLevelLive = (value: number, force = false) => {
+    const now = Date.now()
+    if (!force && now - txLevelThrottleRef.current < 60) return
+    txLevelThrottleRef.current = now
     void setTxLevel(value).catch(() => pushToast('Could not set TX power', 'error'))
   }
 
@@ -4103,10 +4110,24 @@ export function SettingsPanel({
                   min="0"
                   max="1"
                   step="0.01"
-                  value={String(form.txLevel)}
-                  onChange={(e) => updateNum('txLevel', Number(e.target.value))}
-                  onPointerUp={(e) => applyTxLevelLive(Number((e.target as HTMLInputElement).value))}
-                  onKeyUp={(e) => applyTxLevelLive(Number((e.target as HTMLInputElement).value))}
+                  // Slider POSITION is not tx_level directly: position² -> level, √level ->
+                  // position. The real hardware-usable drive range (0 up to just past where
+                  // ALC engages) sits in only the bottom ~15-20% of a linear slider, so a
+                  // square-law curve spreads that critical region across most of the travel.
+                  // The stored/persisted tx_level meaning is completely unchanged — only how
+                  // far the slider has to travel to reach a given level.
+                  value={String(Math.sqrt(form.txLevel))}
+                  onChange={(e) => {
+                    const level = Number(e.target.value) ** 2
+                    updateNum('txLevel', level)
+                    applyTxLevelLive(level)
+                  }}
+                  onPointerUp={(e) =>
+                    applyTxLevelLive(Number((e.target as HTMLInputElement).value) ** 2, true)
+                  }
+                  onKeyUp={(e) =>
+                    applyTxLevelLive(Number((e.target as HTMLInputElement).value) ** 2, true)
+                  }
                   aria-label="Transmit drive level"
                 />
                 <span className="settings-hint">

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -4110,13 +4110,18 @@ export function SettingsPanel({
                   min="0"
                   max="1"
                   step="0.01"
-                  // Slider POSITION is not tx_level directly: position² -> level, √level ->
-                  // position. The real hardware-usable drive range (0 up to just past where
+                  // Slider POSITION is not tx_level directly: position^2 -> level, sqrt(level)
+                  // -> position. The real hardware-usable drive range (0 up to just past where
                   // ALC engages) sits in only the bottom ~15-20% of a linear slider, so a
                   // square-law curve spreads that critical region across most of the travel.
-                  // The stored/persisted tx_level meaning is completely unchanged — only how
-                  // far the slider has to travel to reach a given level.
-                  value={String(Math.sqrt(form.txLevel))}
+                  // The stored/persisted tx_level meaning is completely unchanged - only how
+                  // far the slider has to travel to reach a given level. Rounded to the 0.01
+                  // step grid: an unrounded sqrt() rarely lands on a step boundary, and a
+                  // range input with a step-mismatched value fails HTML5 constraint validation
+                  // - which silently blocks the WHOLE settings form's submit, not just this
+                  // field, the moment this component mounts with a level that doesn't happen
+                  // to have a perfect-square root.
+                  value={String(Math.round(Math.sqrt(form.txLevel) * 100) / 100)}
                   onChange={(e) => {
                     const level = Number(e.target.value) ** 2
                     updateNum('txLevel', level)

--- a/ui/src/components/SettingsPanel.txlevel.test.tsx
+++ b/ui/src/components/SettingsPanel.txlevel.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+//
+// The Tx Power (drive) slider: a square-law position<->level curve and a throttled live-apply.
+//
+// Two bugs, found chasing a multi-second lag between moving this slider and the rig's ALC
+// meter actually settling: (1) this control only committed to the live radio on
+// pointerUp/keyUp, so dragging gave zero feedback until release, then jumped in one step; and
+// (2) once made live on every drag tick, the real hardware-usable drive range (0 up to just
+// past where ALC engages) turned out to sit in only the bottom ~15-20% of a linear slider,
+// leaving almost no travel for the region an operator actually needs to set precisely.
+//
+// Fix: apply live on every onChange, throttled to ~60ms (not gated on release) so it stays
+// responsive without hammering disk (setTxLevel persists the whole settings.json on every
+// call); pointerUp/keyUp force an unthrottled apply so the settled value is never dropped.
+// And a square-law curve (slider position² -> tx_level, √tx_level -> position) so the
+// ALC-critical bottom of the range gets most of the slider's travel. What tx_level itself
+// means to the engine is unchanged — only how far the slider travels to reach a given level.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { SettingsPanel } from './SettingsPanel'
+import type { FeaturesApi } from '../useFeatures'
+import defaultSettings from './__fixtures__/defaultSettings.json'
+
+const api = vi.hoisted(() => {
+  const VERBS = [
+    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
+    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
+    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
+    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
+    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
+    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
+    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
+    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
+    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
+    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
+    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
+    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
+    'getAssistanceJournal', 'setUnassistedMode',
+  ]
+  const spies: Record<string, ReturnType<typeof vi.fn>> = {}
+  const get = (name: string) => {
+    if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
+    return spies[name]
+  }
+  return { spies, get, VERBS }
+})
+
+vi.mock('../api', () => {
+  const mod: Record<string, unknown> = {}
+  for (const v of api.VERBS) mod[v] = api.get(v)
+  return mod
+})
+vi.mock('../toast', () => ({
+  pushToast: vi.fn(),
+  withErrorToast: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}))
+
+/** A serial-CAT radio with tx_level = 0.25, so its slider POSITION under the curve is 0.5. */
+function serialRadio() {
+  const radio = {
+    id: 0,
+    name: 'Radio 1',
+    enabled: true,
+    serialPort: 'COM3',
+    baud: 38400,
+    rigModel: 0,
+    rigModelName: '',
+    rigConn: 'serial',
+    rigAddr: '',
+    rigctldPort: 4532,
+    rotctldPort: 4533,
+    icomNativeCat: false,
+    audioIn: 'in-0',
+    audioOut: 'out-0',
+    txLevel: 0.25,
+    rxGain: 1,
+    pttMethod: 'cat',
+    rotatorModel: 0,
+    rotatorPort: '',
+    rotatorBaud: 9600,
+    rotatorHost: '',
+    nativeScope: 'auto',
+    bands: [],
+  }
+  return {
+    ...defaultSettings,
+    ...radio,
+    mycall: 'KD9TAW',
+    mygrid: 'EN52',
+    activeRadio: 0,
+    radios: [radio],
+  } as never
+}
+
+const features: FeaturesApi = {
+  enabled: () => true,
+  setEnabled: vi.fn(),
+  all: () => [],
+  profile: 'full',
+  setProfile: vi.fn(),
+} as unknown as FeaturesApi
+
+function renderPanel() {
+  return render(
+    <SettingsPanel
+      activeRadioId={0}
+      scale={1 as never}
+      scaleMode={'auto' as never}
+      scaleCap={1 as never}
+      onScaleModeChange={() => {}}
+      onScaleCapChange={() => {}}
+      density={'comfortable' as never}
+      onDensityChange={() => {}}
+      onResetLayout={() => {}}
+      features={features}
+    />,
+  )
+}
+
+beforeEach(() => {
+  for (const spy of Object.values(api.spies)) {
+    spy.mockClear()
+    spy.mockImplementation(() => Promise.resolve(null))
+  }
+  api.get('getSettings').mockImplementation(() => Promise.resolve(serialRadio()))
+  api.get('getRigModels').mockImplementation(() => Promise.resolve([]))
+  api.get('getAllRigModels').mockImplementation(() => Promise.resolve([]))
+  api.get('getSerialPortsDetailed').mockImplementation(() => Promise.resolve([]))
+  api.get('getBandPlan').mockImplementation(() => Promise.resolve([]))
+  api.get('getAudioDevices').mockImplementation(() => Promise.resolve({ input: [], output: [] }))
+  api.get('getCredentialsStatus').mockImplementation(() => Promise.resolve({}))
+  api.get('detectRigs').mockImplementation(() => Promise.resolve([]))
+  api.get('appVersion').mockImplementation(() => Promise.resolve('1.0.1'))
+})
+afterEach(cleanup)
+
+async function openRadioTab() {
+  renderPanel()
+  fireEvent.click(await screen.findByRole('tab', { name: 'Radio' }))
+  await screen.findByLabelText('Transmit drive level')
+}
+
+const slider = () => screen.getByLabelText('Transmit drive level') as HTMLInputElement
+
+describe('Tx Power slider: square-law curve', () => {
+  it('shows slider POSITION as √level, not the raw level', async () => {
+    await openRadioTab()
+    // txLevel is 0.25 -> position is √0.25 = 0.5.
+    expect(Number(slider().value)).toBeCloseTo(0.5, 5)
+  })
+
+  it('onChange squares the slider position back to a level and applies it live', async () => {
+    await openRadioTab()
+    fireEvent.change(slider(), { target: { value: '0.7' } })
+    expect(api.spies.setTxLevel).toHaveBeenCalledWith(0.7 ** 2)
+  })
+})
+
+describe('Tx Power slider: throttled live-apply', () => {
+  it('applies the FIRST change immediately (no gate on release)', async () => {
+    await openRadioTab()
+    fireEvent.change(slider(), { target: { value: '0.6' } })
+    expect(api.spies.setTxLevel).toHaveBeenCalledTimes(1)
+    expect(api.spies.setTxLevel).toHaveBeenCalledWith(0.6 ** 2)
+  })
+
+  it('suppresses a second change inside the throttle window, but pointerUp force-applies', async () => {
+    await openRadioTab()
+    fireEvent.change(slider(), { target: { value: '0.4' } })
+    expect(api.spies.setTxLevel).toHaveBeenCalledTimes(1)
+
+    // Fired immediately after — well inside the ~60ms throttle window in real time.
+    fireEvent.change(slider(), { target: { value: '0.9' } })
+    expect(api.spies.setTxLevel).toHaveBeenCalledTimes(1)
+
+    // Release must still land the final value even though the throttle window is open.
+    fireEvent.pointerUp(slider(), { target: { value: '0.9' } } as never)
+    expect(api.spies.setTxLevel).toHaveBeenCalledTimes(2)
+    expect(api.spies.setTxLevel).toHaveBeenLastCalledWith(0.9 ** 2)
+  })
+})


### PR DESCRIPTION
## Summary

Moving the TX Level / "Pwr" slider doesn't track what's actually being transmitted, which makes it very easy to overshoot into ALC overdrive while trimming drive against a rig's ALC meter. Two separate bugs contribute, plus a follow-on usability fix once both are addressed.

### Bug 1: tune-carrier chunks were sized off a fixed constant, not real elapsed time

`crates/tempo-audio/src/service.rs`: the driving loop ticks every ~20ms, but while Tune was held each audio chunk was sized off the fixed `TUNE_CHUNK_MS` constant (40ms) regardless of how much real time had actually passed. That 2x mismatch between production and playback rate queued audio faster than it could ever drain, so `out_ring` grew without bound for as long as Tune was held  -  confirmed live at 190,000+ queued samples with zero drainage, i.e. several seconds of stale audio reaching the rig regardless of which slider moved it or how "live" that slider was.

**Fix:** size each chunk off real wall-clock time since the last one (new `tune_last_chunk_ms` field), clamped so a stalled tick can't queue one huge catch-up burst. `TUNE_CHUNK_MS` still seeds only the first chunk of a hold, before there's an elapsed-time baseline. Live-retested: `out_ring` now stays bounded around 2,000-3,100 samples instead of climbing past 190,000.

Covered by a new regression test (`service::tests::tune_chunk_pacing_follows_elapsed_time_not_a_fixed_constant`), verified to fail against the old fixed-constant behavior and pass with the fix.

### Bug 2: the Settings panel's Tx Power slider didn't apply while dragging

`ui/src/components/SettingsPanel.tsx`: this slider only committed to the running engine on `pointerUp`/`keyUp`, so dragging gave zero feedback until release, then jumped in one step  -  unlike the cockpit's "Pwr" slider (the same underlying value), which already applied on every `onChange`.

**Fix:** apply live on every change, throttled to ~16Hz  -  `set_tx_level` writes the entire `settings.json` to disk on every call, so applying fully ungated on every drag pixel would trade release-only jank for disk-thrash. A forced, unthrottled apply still fires on release/key-up so the settled value is never silently dropped by the throttle window.

### Follow-on: both sliders' usable range was crushed into the bottom of the travel

With both sliders live, the drive range that actually matters on real hardware (0 up to just past where ALC engages) turned out to sit in only the bottom ~15-20% of the old linear slider  -  the software audio chain is linear end-to-end, so this is the slider's mapping wasting most of its travel, not another timing bug.

**Fix:** both the cockpit and Settings drive sliders now use a square-law curve between slider position and `tx_level` (`position^2 -> level`, `sqrt(level) -> position`), gated to `unit === 'drive'` in `CockpitHeader.tsx` so the unrelated `%` RF-power sliders (Phone/SSTV) stay linear. The stored/persisted `tx_level` value and what it means to the engine are completely unchanged - only how far the slider travels to reach a given level.

Covered by a new test file (`SettingsPanel.txlevel.test.tsx`) for the curve mapping and throttle/force-apply behavior.

## Testing

- `cargo test -p tempo-audio --features device,serial`  -  new regression test passes; confirmed it fails against the pre-fix behavior.
- `tsc -b`  -  clean.
- `npx vitest run src/components/SettingsPanel.txlevel.test.tsx`  -  4/4 passing.
- Live on-air testing (IC-7610) during development of these fixes: "yep thats a fix!"  -  cumulative effect confirmed as a substantial improvement, though real-hardware ALC trimming remains a fine-control task by nature.

## Note on a related, now-unnecessary fix

An earlier version of this work also patched `crates/tempo-audio/src/device.rs` to rescale already-queued `out_ring` samples on a `tx_level` change. That's no longer needed  -  this repo's `main` already applies TX level live in the output callback via an atomic read (see the `// UNSCALED on purpose` comment in `AudioBackend::play`), which is a better fix for the same underlying problem. Only the two bugs above are still present on `main`.
