### PR TITLE
feat(macos): unsigned Nexus.app build script and community packaging path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Nexus (formerly Tempo) are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **macOS from-source `.app` build path.** `./scripts/build-macos.sh` produces an unsigned
+  `Nexus.app` on a Mac with Homebrew’s modem toolchain (cmake/ninja/gcc/fftw/boost). The
+  bundle merges a microphone usage string into Info.plist. This is packaging for operators
+  building locally or sharing community builds — not an Apple-signed official installer.
+
 ## [1.0.5] — 2026-08-08
 
 ### Added

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -179,9 +179,11 @@ for you and AppImage users run `sudo apt install libhamlib-utils` once. On a slo
 **Settings ▸ Modes ▸ Digital (FT8/FT4) ▸ Decode depth ▸ Fast** keeps FT8 and FT4
 decoding in real time.
 
-**macOS does not ship.** The codebase is cross-platform Rust and Tauri, so it is a
-packaging and testing job rather than a port. If you want it, say so on the issue
-tracker — interest is what prioritizes it.
+**macOS is not an official release target yet** (no signed/notarized installer on the
+project’s Releases). The codebase is cross-platform Rust and Tauri — packaging rather
+than a port. You can build an unsigned `Nexus.app` from source with
+`./scripts/build-macos.sh` (see [Building from Source](manual/Building-from-Source.md));
+community interest and reports live on the issue tracker.
 
 ### Will there be automatic updates?
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,7 +12,8 @@ come here for the complete picture.
 
 - **Windows 10 or 11, 64-bit (x64)**, or **Linux**, or a **64-bit Raspberry Pi**
   (Pi 3/4/5). All three build from the same tree and ship together every release.
-  macOS does not ship yet. On a slower Pi, **Settings ▸ Modes ▸ Digital (FT8/FT4) ▸
+  macOS is not an official release target yet (unsigned `.app` via
+  `./scripts/build-macos.sh`). On a slower Pi, **Settings ▸ Modes ▸ Digital (FT8/FT4) ▸
   Decode depth ▸ Fast** keeps FT8 and FT4 decoding in real time.
 - **On a PC, Linux means Ubuntu 24.04 or newer** — Debian 13 (trixie), Fedora 40+, Mint 22
   and anything else built on a C library of at least that vintage. Both PC Linux files are

--- a/docs/launch/wiki/FAQ.md
+++ b/docs/launch/wiki/FAQ.md
@@ -179,9 +179,11 @@ for you and AppImage users run `sudo apt install libhamlib-utils` once. On a slo
 **Settings ▸ Modes ▸ Digital (FT8/FT4) ▸ Decode depth ▸ Fast** keeps FT8 and FT4
 decoding in real time.
 
-**macOS does not ship.** The codebase is cross-platform Rust and Tauri, so it is a
-packaging and testing job rather than a port. If you want it, say so on the issue
-tracker — interest is what prioritises it.
+**macOS is not an official release target yet** (no signed/notarized installer on the
+project’s Releases). The codebase is cross-platform Rust and Tauri — packaging rather
+than a port. You can build an unsigned `Nexus.app` from source with
+`./scripts/build-macos.sh` (see [Building from Source](../manual/Building-from-Source.md));
+community interest and reports live on the issue tracker.
 
 ### Will there be automatic updates?
 

--- a/docs/launch/wiki/Install.md
+++ b/docs/launch/wiki/Install.md
@@ -14,7 +14,8 @@ come here for the complete picture.
 
 - **Windows 10 or 11, 64-bit (x64)**, or **Linux**, or a **64-bit Raspberry Pi**
   (Pi 3/4/5). All three build from the same tree and ship together every release.
-  macOS does not ship yet. On a slower Pi, **Settings ▸ Modes ▸ Digital (FT8/FT4) ▸
+  macOS is not an official release target yet (unsigned `.app` via
+  `./scripts/build-macos.sh`). On a slower Pi, **Settings ▸ Modes ▸ Digital (FT8/FT4) ▸
   Decode depth ▸ Fast** keeps FT8 and FT4 decoding in real time.
 - **A radio with CAT + audio**, or a network rig (FlexRadio, remote `rigctld`).
   You can install and explore without a radio — the wizard and every panel open —

--- a/docs/manual/Building-from-Source.md
+++ b/docs/manual/Building-from-Source.md
@@ -72,6 +72,42 @@ No MSYS2 needed; produces the same installer.
 
 ---
 
+## Path C — Native macOS (Homebrew)
+
+Produces an **unsigned** `Nexus.app` (Gatekeeper: right-click → Open). Official Apple-signed / notarized packages are a separate maintainer decision; this path is for operators building from source or community builds.
+
+1. **Install Xcode Command Line Tools** (WKWebView is already part of macOS):
+
+   ```bash
+   xcode-select --install
+   ```
+
+2. **Install Homebrew deps + Rust + Node:**
+
+   ```bash
+   brew install cmake ninja gcc fftw boost pkgconf
+   # CAT / rig control (not bundled in the .app):
+   brew install hamlib
+   ```
+
+   - Rust via [rustup](https://rustup.rs) (match the toolchain pin in CI, currently 1.93.1).
+   - [Node.js LTS](https://nodejs.org/) for the UI build.
+   - `cargo install tauri-cli --version "^2"` (the script installs it if missing).
+
+3. **Stage the DeepCW model** into `src-tauri/resources/deepcw/` (see that folder’s README), **or** pass `--allow-missing-aicw` / `NEXUS_ALLOW_MISSING_AICW=1` for a build without the AI CW decoder.
+
+4. **Build:**
+
+   ```bash
+   ./scripts/build-macos.sh
+   ```
+
+   Artifact: `src-tauri/target/release/bundle/macos/Nexus.app`.
+
+The script sets `LIBRARY_PATH` for Homebrew’s `libgfortran` and `libfftw3f`, and temporarily turns off Tauri updater artifact signing for the local run (no private key on a community machine).
+
+---
+
 ## Headless modem / engine tests (any platform)
 
 You don't need WebView2 or a radio to run the test suite — just the native modem toolchain so `ft1-sys` can build `libtempo` via CMake.

--- a/docs/manual/FAQ.md
+++ b/docs/manual/FAQ.md
@@ -12,7 +12,7 @@ Yes. Nexus is **GPLv3** open-source software. Source lives at [kd9taw/nexus](htt
 
 ### What operating systems does Nexus run on?
 
-**Windows, Linux and Raspberry Pi** all ship, built from the same tree every release: an NSIS installer, an AppImage, a PC `.deb`, and a `.deb` per live Raspberry Pi OS base. **macOS is not packaged yet** and no mobile or web client exists — see [Roadmap](Roadmap.md).
+**Windows, Linux and Raspberry Pi** all ship, built from the same tree every release: an NSIS installer, an AppImage, a PC `.deb`, and a `.deb` per live Raspberry Pi OS base. **macOS is not an official release target yet** (build an unsigned `.app` with `./scripts/build-macos.sh`) and no mobile or web client exists — see [Roadmap](Roadmap.md) and [Building from Source](Building-from-Source.md).
 
 ---
 
@@ -113,7 +113,7 @@ Yes — a live single-signal decoder follows the station at your marker pitch an
 
 ### Does Nexus run on Linux or macOS?
 
-The desktop shell is packaged for **Windows, Linux and Raspberry Pi**, all from the same tree. **macOS is not packaged yet**; the codebase is cross-platform Rust and Tauri, so it is a packaging and testing job rather than a port. You can also build any platform from source — see [Building from Source](Building-from-Source.md).
+The desktop shell is packaged for **Windows, Linux and Raspberry Pi**, all from the same tree. **macOS is not an official release target yet** (no signed/notarized installer); you can build an unsigned `Nexus.app` from source with `./scripts/build-macos.sh` — see [Building from Source](Building-from-Source.md).
 
 ---
 

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Nexus — native macOS build, producing an unsigned Nexus.app bundle.
+#
+#   ./scripts/build-macos.sh                 # UI + modem + Nexus.app
+#   ./scripts/build-macos.sh --allow-missing-aicw
+#   ./scripts/build-macos.sh --no-gui         # native modem CMake check only
+#
+# One-time deps (Homebrew):
+#   brew install cmake ninja gcc fftw boost pkgconf
+#   + Xcode CLT, rustup, Node.js; cargo-tauri is auto-installed if absent.
+#   CAT: brew install hamlib  (rigctld on PATH — not bundled in the .app)
+#
+# This is the community / from-source path. Official signed+notarized macOS
+# packages are a separate maintainer decision (Apple Developer ID). Unsigned
+# builds are expected to trip Gatekeeper (right-click → Open), same class of
+# warning as the unsigned Windows installer and SmartScreen.
+set -euo pipefail
+
+bold() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$*"; }
+die()  { printf '\n\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+[ -f "$HOME/.nexus-build.env" ] && source "$HOME/.nexus-build.env"
+
+GUI=1
+ALLOW_MISSING_AICW=0
+for a in "$@"; do
+  case "$a" in
+    --no-gui) GUI=0 ;;
+    --allow-missing-aicw) ALLOW_MISSING_AICW=1 ;;
+    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown option: $a" ;;
+  esac
+done
+
+command -v brew >/dev/null || die "Homebrew not found — install from https://brew.sh"
+
+# 1 — toolchain --------------------------------------------------------------------------------
+bold "1/4  Toolchain + Homebrew modem libraries"
+miss=()
+for t in cc gfortran cmake ninja node npm pkg-config; do
+  command -v "$t" >/dev/null || miss+=("$t")
+done
+command -v cargo >/dev/null || die "Rust not found — install from https://rustup.rs"
+[ "${#miss[@]}" -eq 0 ] || die "missing tools: ${miss[*]}
+  brew install cmake ninja gcc fftw boost pkgconf
+  (+ Node.js LTS from https://nodejs.org/)"
+
+pkg-config --exists fftw3f 2>/dev/null || die "fftw (single-precision) missing — brew install fftw"
+# Homebrew's libgfortran lives under the gcc formula, not on the default linker path.
+export LIBRARY_PATH="$(brew --prefix gcc)/lib/gcc/current:$(brew --prefix fftw)/lib:${LIBRARY_PATH:-}"
+export PKG_CONFIG_PATH="$(brew --prefix fftw)/lib/pkgconfig:$(brew --prefix boost)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+ok "cc/gfortran/cmake/ninja/node, Homebrew FFTW3f + libgfortran on LIBRARY_PATH"
+
+# DeepCW model — same contract as build-linux.sh. Absent model ⇒ silent lobotomy of AI CW.
+if [ "$GUI" = 1 ]; then
+  dcw="$REPO/src-tauri/resources/deepcw"
+  missing=0
+  for f in model.onnx model.onnx.json; do
+    [ -s "$dcw/$f" ] || missing=1
+  done
+  if [ "$missing" = 1 ]; then
+    if [ "$ALLOW_MISSING_AICW" = 1 ] || [ "${NEXUS_ALLOW_MISSING_AICW:-}" = 1 ]; then
+      warn "DeepCW model missing — continuing with NEXUS_ALLOW_MISSING_AICW (no AI CW decoder)"
+      export NEXUS_ALLOW_MISSING_AICW=1
+    else
+      die "missing $dcw/model.onnx (and/or model.onnx.json) — stage the DeepCW model
+  before bundling, or pass --allow-missing-aicw / NEXUS_ALLOW_MISSING_AICW=1.
+  See src-tauri/resources/deepcw/README.md."
+    fi
+  else
+    ok "DeepCW model staged ($(du -h "$dcw/model.onnx" | cut -f1))"
+  fi
+fi
+
+# 2 — libtempo native modem (proves the Fortran/CMake chain) -----------------------------------
+bold "2/4  libtempo native modem (CMake)"
+cmake -S "$REPO/libtempo" -B "$REPO/libtempo/build-macos" -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  ${WX:+-DWX="$WX"} >/dev/null
+cmake --build "$REPO/libtempo/build-macos" >/dev/null
+ok "libtempo/build-macos"
+
+if [ "$GUI" = 0 ]; then bold "Modem build done (--no-gui)."; exit 0; fi
+
+# 3 — UI ---------------------------------------------------------------------------------------
+bold "3/4  Web UI dependencies"
+( cd "$REPO/ui" && npm install >/dev/null )
+ok "ui/node_modules"
+
+# 4 — Tauri .app -------------------------------------------------------------------------------
+bold "4/4  Nexus.app (unsigned)"
+cargo tauri --version >/dev/null 2>&1 || {
+  warn "installing tauri-cli…"
+  cargo install tauri-cli --version "^2" --locked
+}
+[ -f "$REPO/src-tauri/icons/128x128.png" ] || python3 "$REPO/scripts/gen-icons.py"
+
+# With a pubkey configured, Tauri hard-errors if createUpdaterArtifacts is true and no
+# private signing key is present (same trap as the Pi Docker build). Flip it off for this
+# local run only; restore on exit so the working tree stays clean.
+CONF="$REPO/src-tauri/tauri.conf.json"
+CONF_BAK="$(mktemp)"
+cp "$CONF" "$CONF_BAK"
+restore_conf() { cp "$CONF_BAK" "$CONF"; rm -f "$CONF_BAK"; }
+trap restore_conf EXIT
+python3 - "$CONF" <<'PY'
+import json, sys
+p = sys.argv[1]
+with open(p) as f:
+    c = json.load(f)
+c.setdefault("bundle", {})["createUpdaterArtifacts"] = False
+with open(p, "w") as f:
+    json.dump(c, f, indent=2)
+    f.write("\n")
+PY
+
+( cd "$REPO/src-tauri" && cargo tauri build --features radio,custom-protocol --bundles app )
+ok "Nexus.app"
+
+bold "Done ✓  macOS artifact:"
+echo "  app : src-tauri/target/release/bundle/macos/Nexus.app"
+echo
+warn "Unsigned build — Gatekeeper: right-click Nexus.app → Open."
+warn "CAT needs Hamlib on PATH: brew install hamlib  (rigctld)."

--- a/src-tauri/Info.plist.macos
+++ b/src-tauri/Info.plist.macos
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Nexus needs microphone (or audio interface) access for receive audio and voice keyer recording.</string>
+</dict>
+</plist>

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -140,7 +140,11 @@ A graphical session (X11 or Wayland) is required to actually open the window.
 
 - **Xcode Command Line Tools**: `xcode-select --install`
   (WKWebView ships with macOS — no extra runtime needed).
+- Homebrew modem deps: `brew install cmake ninja gcc fftw boost pkgconf`
+  (and `brew install hamlib` for `rigctld` on PATH — CAT is not bundled in the `.app`).
 - Rust via `rustup` and Node.js + npm.
+- From the repo root: `./scripts/build-macos.sh` →
+  `src-tauri/target/release/bundle/macos/Nexus.app` (unsigned; Gatekeeper right-click → Open).
 
 ---
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -82,6 +82,11 @@
       "deb": {
         "depends": ["libhamlib-utils"]
       }
+    },
+    "macOS": {
+      "minimumSystemVersion": "11.0",
+      "hardenedRuntime": false,
+      "infoPlist": "Info.plist.macos"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

- Adds `./scripts/build-macos.sh` to produce an **unsigned** `Nexus.app` on macOS with Homebrew’s modem toolchain (cmake/ninja/gcc/fftw/boost), matching the Linux/Windows from-source scripts.
- Merges microphone usage text via `src-tauri/Info.plist.macos` (`bundle.macOS` in `tauri.conf.json`).
- Documents the path in Building from Source / FAQ; CHANGELOG under Unreleased.

Built and validated on an Intel Mac by **Rogerio Pires, PY2EQ** (amateur radio operator).

Closes nothing by itself — tracks interest in https://github.com/kd9taw/Nexus/issues/6.

## Community download (already online)

For operators who want to try a build before this lands:

- Release: https://github.com/rogpires/Nexus/releases/tag/macos-community-1.0.5
- Zip: https://github.com/rogpires/Nexus/releases/download/macos-community-1.0.5/Nexus-1.0.5-macos-x86_64.zip

That pre-release is **community / unsigned** (Gatekeeper: right-click → Open). It is **not** an official KD9TAW release. AI CW model not bundled; CAT needs `brew install hamlib`.

## Notes for maintainers

- No Apple Developer ID / notarization in this PR — intentional. Official signed shipping can stay a separate decision.
- The build script temporarily disables `createUpdaterArtifacts` for the local run (same trap as the Pi Docker build when no Tauri signing private key is present).
- `--allow-missing-aicw` / `NEXUS_ALLOW_MISSING_AICW=1` for CI-style builds without DeepCW.

## Test plan

- [ ] On macOS + Homebrew deps: `./scripts/build-macos.sh --allow-missing-aicw` produces `src-tauri/target/release/bundle/macos/Nexus.app`
- [ ] `Info.plist` inside the bundle contains `NSMicrophoneUsageDescription`
- [ ] App launches (Gatekeeper right-click → Open on unsigned build)
- [ ] With `rigctld` on PATH, CAT setup can find Hamlib


Made with [Cursor](https://cursor.com)