### PR TITLE
Emit macOS linker search paths for the gfortran and FFTW3f runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,7 +496,11 @@ jobs:
         env:
           NEXUS_ALLOW_MISSING_AICW: 1
         run: |
-          export LIBRARY_PATH="$(brew --prefix gcc)/lib/gcc/current:$(brew --prefix fftw)/lib:${LIBRARY_PATH:-}"
+          # NO LIBRARY_PATH export here, deliberately. It used to supply exactly the two directories
+          # tempo-fast-sys/build.rs now derives (gcc's lib/gcc/current and fftw's lib), which meant
+          # this job passed whether or not the probe worked -- green either way is not a test. Without
+          # it, the job IS the positive control for the probe: if the derivation breaks, the link
+          # fails here rather than on a contributor's Mac.
           cargo build --release \
             --manifest-path src-tauri/Cargo.toml \
             --target aarch64-apple-darwin \

--- a/crates/tempo-fast-sys/build.rs
+++ b/crates/tempo-fast-sys/build.rs
@@ -80,6 +80,17 @@ fn main() {
     // Link: static libtempo first, then its runtime dependencies.
     println!("cargo:rustc-link-search=native={}", out.display());
     println!("cargo:rustc-link-lib=static=tempo");
+    // macOS has no system Fortran and no Homebrew dir on the default linker path, so
+    // -lgfortran/-lfftw3f below resolve on Linux (/usr/lib) but fail on macOS with
+    // "ld: library 'gfortran' not found". Ask the toolchain where its own libraries
+    // are rather than hardcoding a prefix — that keeps this right on both Apple
+    // Silicon (/opt/homebrew) and Intel (/usr/local), and across gcc revisions.
+    // TARGET, not host: `cfg!(target_os)` in a build script describes the machine the script
+    // itself was compiled for, so cross-compiling FROM a Mac would wrongly emit these. The file
+    // already draws that distinction for Windows (`is_cross_to_windows_gnu`); same rule here.
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        emit_macos_runtime_search_paths();
+    }
     println!("cargo:rustc-link-lib=dylib=gfortran");
     println!("cargo:rustc-link-lib=dylib=fftw3f");
     println!("cargo:rustc-link-lib=dylib=stdc++");
@@ -90,6 +101,53 @@ fn main() {
     }
 
     emit_rerun(&libtempo_src);
+}
+
+/// Emit `rustc-link-search` entries for the gfortran and FFTW3f runtimes on macOS.
+///
+/// Both are Homebrew-provided and neither prefix (`/opt/homebrew` on Apple Silicon,
+/// `/usr/local` on Intel) is on Apple ld's default search path. Each location is
+/// resolved by asking the relevant tool, so no prefix is baked in:
+///
+/// * `gfortran -print-file-name=libgfortran.dylib` — the compiler reports the
+///   absolute path of its own runtime; its parent directory also holds libquadmath.
+/// * `pkg-config --libs-only-L fftw3f` — the same source CMake uses for FFTW.
+///
+/// A probe that fails is skipped rather than fatal: the link may still succeed if
+/// the libraries are somewhere the linker already looks, and a real miss surfaces
+/// as the ld error above with better context than a build-script panic.
+fn emit_macos_runtime_search_paths() {
+    let fortran = env::var("FC").unwrap_or_else(|_| "gfortran".into());
+    if let Some(dir) = Command::new(&fortran)
+        .arg("-print-file-name=libgfortran.dylib")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|p| PathBuf::from(p.trim()))
+        // -print-file-name echoes the bare name back when it cannot resolve it.
+        .filter(|p| p.is_absolute())
+        .and_then(|p| p.parent().map(PathBuf::from))
+        // The reported path runs through `../../..` segments; canonicalize so the
+        // emitted -L is the real directory.
+        .and_then(|d| d.canonicalize().ok())
+    {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+    }
+
+    if let Ok(out) = Command::new("pkg-config")
+        .args(["--libs-only-L", "fftw3f"])
+        .output()
+    {
+        if out.status.success() {
+            for dir in String::from_utf8_lossy(&out.stdout)
+                .split_whitespace()
+                .filter_map(|f| f.strip_prefix("-L"))
+            {
+                println!("cargo:rustc-link-search=native={dir}");
+            }
+        }
+    }
 }
 
 /// True when cross-compiling to `*-pc-windows-gnu` from a non-Windows host.

--- a/crates/tempo-fast-sys/build.rs
+++ b/crates/tempo-fast-sys/build.rs
@@ -117,6 +117,10 @@ fn main() {
 /// the libraries are somewhere the linker already looks, and a real miss surfaces
 /// as the ld error above with better context than a build-script panic.
 fn emit_macos_runtime_search_paths() {
+    // Same rule as WX above: cargo does not re-run a build script when an env var it READS
+    // changes unless told to, so pointing FC at a different toolchain would otherwise keep
+    // the previously-probed paths.
+    println!("cargo:rerun-if-env-changed=FC");
     let fortran = env::var("FC").unwrap_or_else(|_| "gfortran".into());
     if let Some(dir) = Command::new(&fortran)
         .arg("-print-file-name=libgfortran.dylib")


### PR DESCRIPTION
## Summary

A from-source build cannot link on macOS. `crates/tempo-fast-sys/build.rs` emits
`cargo:rustc-link-lib=dylib=gfortran` (and `fftw3f`) but adds a link-search only for its own CMake
output. On Linux those resolve from `/usr/lib`; macOS ships no system Fortran and Apple's `ld`
never searches Homebrew's prefix, so the link fails with:

    ld: library 'gfortran' not found

This asks the toolchain where its own libraries are — `gfortran -print-file-name=libgfortran.dylib`
for the GCC runtime, `pkg-config --libs-only-L fftw3f` for FFTW — rather than hardcoding a prefix,
so it holds on both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`), and across gcc
revisions where a hardcoded path would need updating for each.

Gated on `CARGO_CFG_TARGET_OS`, not `cfg!(target_os)`: in a build script the latter describes the
machine the script was compiled for, so cross-compiling *from* a Mac would wrongly emit these.
This file already draws that distinction for the Windows cross path; same rule applied here.

A failed probe is skipped rather than fatal — the link may still succeed if the libraries sit
where the linker already looks, and a genuine miss then surfaces as the `ld` error above with
better context than a build-script panic.

The Linux and Windows paths are untouched.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench / hardware — Apple Silicon (M-series), macOS 26, Homebrew gcc 14.2 and fftw 3.3.10.
- **Notes:** Checked in both directions, not just the happy path. On current `main`,
  `cargo test -p tempo-fast-sys --no-run` fails with the verbatim `ld: library 'gfortran' not found`;
  with this patch it links and the suite runs. This is a build-time linker change only — no runtime,
  waveform or on-air behaviour is involved, and nothing here was validated on the air.

## Checklist

- [x] `cargo test` passes on the workspace (headless modem + engine + net + TempoDeep round-trips).
- [x] `cargo clippy --all-targets` is clean (no new warnings) — checked on the CI-pinned 1.93.1.
- [x] UI touched? No UI change in this PR.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
