### PR TITLE
Verify a resolved rigctld actually runs before committing to it

### DIFF
--- a/crates/tempo-audio/src/rigctld_proc.rs
+++ b/crates/tempo-audio/src/rigctld_proc.rs
@@ -672,19 +672,6 @@ fn path_has(path_var: &std::ffi::OsStr, bin_name: &str) -> bool {
     std::env::split_paths(path_var).any(|dir| dir.join(bin_name).is_file())
 }
 
-/// Does the CURRENT process's own `PATH` already resolve `bin_name`? Read-only mirror of the
-/// search `Command::new(bin_name)` is about to do itself.
-///
-/// **Why check this instead of just always trying [`HAMLIB_SEARCH_DIRS`] first.** An operator
-/// (or a test) may deliberately put a specific `rigctld` earliest on `PATH` — a version pin, a
-/// wrapper script, a fixture stand-in — and that intent must outrank Nexus's own guess at common
-/// install directories. [`HAMLIB_SEARCH_DIRS`] exists for the case PATH has NOTHING, not to
-/// second-guess a PATH that already has something.
-#[cfg(unix)]
-fn on_path(bin_name: &str) -> bool {
-    std::env::var_os("PATH").is_some_and(|path| path_has(&path, bin_name))
-}
-
 /// Does `bin` actually RUN, or does it merely exist?
 ///
 /// Existence is not usability, and the gap is not hypothetical: a Hamlib built from source and
@@ -750,18 +737,59 @@ fn runs_ok(bin: &std::ffi::OsStr) -> bool {
 /// `Command` produces its own normal "not found" error, exactly as before.
 #[cfg(unix)]
 fn resolve_hamlib_bin(bin_name: &str) -> std::ffi::OsString {
-    if on_path(bin_name) && runs_ok(std::ffi::OsStr::new(bin_name)) {
-        return bin_name.into();
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    resolve_hamlib_bin_in(&path_var, HAMLIB_SEARCH_DIRS, bin_name)
+}
+
+/// The testable core of [`resolve_hamlib_bin`] — takes the `PATH` value and the search directories
+/// as parameters instead of reading the real process environment, exactly as [`path_has`] and
+/// [`find_in_dirs`] already do, and for the same reason: the behaviour worth pinning is "a broken
+/// first candidate is SKIPPED and a working one in a later directory wins", and that cannot be
+/// driven at all while the inputs are global.
+///
+/// Every rejection is announced. The complaint this whole change answers is that CAT was dead
+/// "with no diagnosis anywhere in the app"; skipping a candidate silently would leave the operator
+/// exactly where they started, just one directory further along. A total miss says so too, because
+/// handing `Command` the bare name after everything failed is the case most likely to end in an
+/// unexplained spawn error later.
+#[cfg(unix)]
+fn resolve_hamlib_bin_in(
+    path_var: &std::ffi::OsStr,
+    dirs: &[&str],
+    bin_name: &str,
+) -> std::ffi::OsString {
+    // PATH FIRST, and that ordering is deliberate. An operator (or a test) may put a specific
+    // rigctld earliest on PATH — a version pin, a wrapper script, a fixture stand-in — and that
+    // intent must outrank Nexus's own guess at common install directories. HAMLIB_SEARCH_DIRS
+    // exists for the case PATH has NOTHING, not to second-guess a PATH that already has something.
+    // (What is new here is only that the PATH copy must also RUN before it is committed to.)
+    if path_has(path_var, bin_name) {
+        if runs_ok(std::ffi::OsStr::new(bin_name)) {
+            return bin_name.into();
+        }
+        crate::civ::diag::note(&format!(
+            "{bin_name}: the copy first on PATH cannot run (killed by a signal — typically a \
+             library it needs is missing or unloadable); trying the package-manager directories"
+        ));
     }
     // One directory at a time rather than one `find_in_dirs` call over all of them: the first
     // directory that merely CONTAINS the binary is no longer necessarily the answer, so each
     // candidate has to clear `runs_ok` before the search stops.
-    for dir in HAMLIB_SEARCH_DIRS {
+    for dir in dirs {
         match find_in_dirs(std::slice::from_ref(dir), bin_name) {
             Some(p) if runs_ok(&p) => return p,
-            _ => continue,
+            Some(p) => crate::civ::diag::note(&format!(
+                "{bin_name}: {} cannot run — skipping it",
+                p.to_string_lossy()
+            )),
+            None => continue,
         }
     }
+    crate::civ::diag::note(&format!(
+        "{bin_name}: no runnable copy found on PATH or in {} known install \
+         directories — CAT will not start",
+        dirs.len()
+    ));
     bin_name.into()
 }
 
@@ -1281,6 +1309,66 @@ mod tests {
         assert_eq!(find_in_dirs(&[dir_str], "rotctld"), None);
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// THE BEHAVIOUR THIS CHANGE BUYS, driven end to end: a first candidate that cannot RUN is
+    /// skipped, and a working copy in a later directory wins.
+    ///
+    /// Reported on macOS 2026-08-13, but the mechanism is not platform-specific: a Hamlib built
+    /// from source keeps its configured `--prefix` as its dylib load path, so every binary in it is
+    /// executable, first on `PATH`, and dies at the loader before `main`. The old resolver
+    /// committed to it because it EXISTED, and never consulted the directory list that had a
+    /// working copy one entry later. CAT was simply dead.
+    ///
+    /// The stubs stand in for that: dir A's exits by SIGABRT, which is precisely what an unloadable
+    /// binary does; dir B's exits 0. `runs_ok` must reject only the first.
+    #[cfg(unix)]
+    #[test]
+    fn a_candidate_that_cannot_run_is_skipped_for_one_that_can() {
+        let root = std::env::temp_dir().join(format!(
+            "nexus-resolve-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let broken = root.join("a");
+        let working = root.join("b");
+        std::fs::create_dir_all(&broken).unwrap();
+        std::fs::create_dir_all(&working).unwrap();
+
+        // `kill -ABRT $$` is how a dyld failure presents: death by signal, not a non-zero exit.
+        // The distinction is the whole rule -- a non-zero EXIT is a pass (wrapper scripts, version
+        // pins and this crate's own rigctld stand-in all exit non-zero on an unknown flag).
+        let write_stub = |dir: &std::path::Path, body: &str| {
+            let p = dir.join("rigctld");
+            std::fs::write(&p, body).unwrap();
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+            p
+        };
+        write_stub(&broken, "#!/bin/sh\nkill -ABRT $$\n");
+        let good = write_stub(&working, "#!/bin/sh\nexit 0\n");
+
+        let dirs = [broken.to_str().unwrap(), working.to_str().unwrap()];
+        // Empty PATH: this test is about the DIRECTORY search, and it must never depend on the
+        // real environment (see `path_has_is_true_only_when_a_search_dir_actually_has_it`).
+        let got = resolve_hamlib_bin_in(std::ffi::OsStr::new(""), &dirs, "rigctld");
+
+        assert_eq!(
+            std::path::Path::new(&got),
+            good,
+            "the working copy in the LATER directory must win; got {got:?}"
+        );
+
+        // And with only the broken one available there is nothing to fall back to, so the bare
+        // name comes back -- the caller's spawn then fails loudly instead of silently using it.
+        let only_broken = [broken.to_str().unwrap()];
+        let fallback = resolve_hamlib_bin_in(std::ffi::OsStr::new(""), &only_broken, "rigctld");
+        assert_eq!(fallback, std::ffi::OsString::from("rigctld"));
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     /// The priority guard: [`HAMLIB_SEARCH_DIRS`] must never outrank a `rigctld` the operator (or

--- a/crates/tempo-audio/src/rigctld_proc.rs
+++ b/crates/tempo-audio/src/rigctld_proc.rs
@@ -685,6 +685,86 @@ fn on_path(bin_name: &str) -> bool {
     std::env::var_os("PATH").is_some_and(|path| path_has(&path, bin_name))
 }
 
+/// Does `bin` actually RUN, or does it merely exist?
+///
+/// Existence is not usability, and the gap is not hypothetical: a Hamlib built from source and
+/// installed under `~/.local` keeps the configured `--prefix` (`/usr/local/lib/libhamlib.4.dylib`)
+/// as its dylib load path, so every `rigctl*` binary is executable, first on `PATH`, and dies at
+/// `dyld` load with *"Library not loaded"* before `main`. Found on a real station on 2026-08-13:
+/// CAT was dead with no usable diagnosis, because [`on_path`] said yes and the
+/// [`HAMLIB_SEARCH_DIRS`] fallback — which would have found a working Homebrew Hamlib one
+/// directory later — was never consulted.
+///
+/// `--version` is the probe: it touches no serial port, binds no TCP port, and returns at once.
+///
+/// **A NON-ZERO EXIT IS A PASS — only a SIGNAL is a failure.** This is the whole subtlety, and
+/// getting it wrong silently breaks the [`resolve_rigctld`] contract that an operator's or a
+/// test's own binary outranks Nexus's guesses. A wrapper script, a version pin, or the stand-in
+/// in `service`'s `an_ordinary_connect_failure_carries_what_the_daemon_said` need not implement
+/// `--version` at all — that fixture answers only `-vvv` and exits 9 for anything else — and
+/// rejecting them for it would hand Nexus's own guess a veto over a deliberate choice. A binary
+/// whose libraries cannot be loaded fails differently: `dyld` calls `abort()` before `main`, so
+/// the process is KILLED BY SIGABRT rather than returning an exit code (observed: 134, i.e.
+/// 128+6, from the `~/.local` Hamlib above). Signal death, failure to exec at all, and a hang are
+/// the three "this cannot run" verdicts; every ordinary exit status means it ran.
+///
+/// The wait is BOUNDED because this sits on the CAT-connect path: a candidate that hangs must not
+/// hang Nexus, so it is killed and treated as unusable rather than waited on.
+#[cfg(unix)]
+fn runs_ok(bin: &std::ffi::OsStr) -> bool {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{Command, Stdio};
+    let mut child = match Command::new(bin)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return false, // not executable at all (ENOENT / EACCES / bad arch)
+    };
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2_000);
+    loop {
+        match child.try_wait() {
+            // Exited on its own terms — ANY code, see above. Only signal death disqualifies.
+            Ok(Some(status)) => return status.signal().is_none(),
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return false;
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
+            Err(_) => return false,
+        }
+    }
+}
+
+/// Resolve a Hamlib binary on Unix: the operator's `PATH` first, then [`HAMLIB_SEARCH_DIRS`],
+/// requiring at each step that the candidate actually runs ([`runs_ok`]).
+///
+/// The PATH-first order is deliberate and unchanged — an operator who puts a specific build
+/// earliest on `PATH` (a version pin, a wrapper, a fixture) still outranks Nexus's guesses. What
+/// changed is that a candidate which cannot execute no longer counts as a resolution and no
+/// longer suppresses the fallback. Falling all the way through returns the bare name so
+/// `Command` produces its own normal "not found" error, exactly as before.
+#[cfg(unix)]
+fn resolve_hamlib_bin(bin_name: &str) -> std::ffi::OsString {
+    if on_path(bin_name) && runs_ok(std::ffi::OsStr::new(bin_name)) {
+        return bin_name.into();
+    }
+    // One directory at a time rather than one `find_in_dirs` call over all of them: the first
+    // directory that merely CONTAINS the binary is no longer necessarily the answer, so each
+    // candidate has to clear `runs_ok` before the search stops.
+    for dir in HAMLIB_SEARCH_DIRS {
+        match find_in_dirs(std::slice::from_ref(dir), bin_name) {
+            Some(p) if runs_ok(&p) => return p,
+            _ => continue,
+        }
+    }
+    bin_name.into()
+}
+
 /// Locate the `rigctld` binary. Prefers one **bundled next to the app** — the
 /// Windows installer ships Hamlib under the install dir (with its DLLs), so CAT
 /// works with no separate Hamlib install — then whatever `rigctld` the process's own `PATH`
@@ -709,12 +789,13 @@ fn resolve_rigctld() -> std::ffi::OsString {
         }
     }
     #[cfg(unix)]
-    if !on_path("rigctld") {
-        if let Some(p) = find_in_dirs(HAMLIB_SEARCH_DIRS, "rigctld") {
-            return p;
-        }
+    {
+        resolve_hamlib_bin("rigctld")
     }
-    std::ffi::OsString::from("rigctld")
+    #[cfg(not(unix))]
+    {
+        std::ffi::OsString::from("rigctld")
+    }
 }
 
 /// Build the `rotctld` argument vector — same shape as [`rigctld_args`] minus
@@ -755,12 +836,13 @@ fn resolve_rotctld() -> std::ffi::OsString {
         }
     }
     #[cfg(unix)]
-    if !on_path("rotctld") {
-        if let Some(p) = find_in_dirs(HAMLIB_SEARCH_DIRS, "rotctld") {
-            return p;
-        }
+    {
+        resolve_hamlib_bin("rotctld")
     }
-    std::ffi::OsString::from("rotctld")
+    #[cfg(not(unix))]
+    {
+        std::ffi::OsString::from("rotctld")
+    }
 }
 
 /// Spawn `rotctld` for a ROTATOR `model` on `port`@`baud`, listening on
@@ -916,12 +998,13 @@ pub(crate) fn resolve_rigctl() -> std::ffi::OsString {
         }
     }
     #[cfg(unix)]
-    if !on_path("rigctl") {
-        if let Some(p) = find_in_dirs(HAMLIB_SEARCH_DIRS, "rigctl") {
-            return p;
-        }
+    {
+        resolve_hamlib_bin("rigctl")
     }
-    std::ffi::OsString::from("rigctl")
+    #[cfg(not(unix))]
+    {
+        std::ffi::OsString::from("rigctl")
+    }
 }
 
 /// One conf parameter out of a `rigctld --show-conf` dump, as `(value, combo tokens)`.
@@ -1104,6 +1187,66 @@ pub fn spawn_rigctld(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Write `body` as an executable shell script in a fresh temp dir and return its path.
+    #[cfg(unix)]
+    fn stub_script(tag: &str, body: &str) -> std::path::PathBuf {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!(
+            "nexus-runs-ok-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let p = dir.join("rigctld");
+        std::fs::File::create(&p)
+            .and_then(|mut f| f.write_all(body.as_bytes()))
+            .expect("write stub");
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        p
+    }
+
+    /// [`runs_ok`] must separate "ran and said no" from "could not run at all".
+    ///
+    /// The bug this guards is a REGRESSION THAT ALREADY HAPPENED once, on 2026-08-13: written as
+    /// `status.success()`, the probe rejected every binary that exits non-zero for an unknown
+    /// flag — which is most wrapper scripts and, concretely, the `rigctld` stand-in in
+    /// `service`'s `an_ordinary_connect_failure_carries_what_the_daemon_said` (it answers `-vvv`
+    /// and exits 9 otherwise). Nexus then silently overrode a deliberately-chosen binary with its
+    /// own `HAMLIB_SEARCH_DIRS` guess, exactly what [`resolve_rigctld`]'s contract forbids. Only
+    /// death by SIGNAL — how `dyld` reports unloadable libraries, via `abort()` before `main` —
+    /// means unusable. Anyone tempted to "simplify" this back to `.success()` fails here.
+    #[cfg(unix)]
+    #[test]
+    fn runs_ok_accepts_a_nonzero_exit_and_rejects_only_a_signal() {
+        // Exits 9 for an unknown flag — the shape of the service.rs fixture and of real wrappers.
+        let picky = stub_script("picky", "#!/bin/sh\n[ \"$1\" = \"-vvv\" ] || exit 9\n");
+        assert!(
+            runs_ok(picky.as_os_str()),
+            "a stand-in that exits non-zero for --version still RUNS; rejecting it lets Nexus \
+             override an operator's or a test's deliberate choice of binary"
+        );
+
+        // Killed by SIGABRT — how a binary whose dylibs cannot be loaded dies.
+        let aborts = stub_script("aborts", "#!/bin/sh\nkill -ABRT $$\n");
+        assert!(
+            !runs_ok(aborts.as_os_str()),
+            "signal death is the unloadable-library signature and must be rejected"
+        );
+
+        // Not executable at all.
+        assert!(
+            !runs_ok(std::ffi::OsStr::new("/nonexistent-nexus-test-dir/rigctld")),
+            "a path that cannot be spawned is not usable"
+        );
+
+        for p in [picky, aborts] {
+            if let Some(d) = p.parent() {
+                let _ = std::fs::remove_dir_all(d);
+            }
+        }
+    }
 
     /// Repro for the 2026-08-07 macOS report: `rigctld` installed via Homebrew, `which rigctld`
     /// works in every terminal, and Nexus still can't spawn it — because a Finder-launched app's


### PR DESCRIPTION
## Summary

`resolve_rigctld` / `rotctld` / `rigctl` treat "exists on `PATH`" as usable. A Hamlib built from
source under a custom `--prefix` keeps that prefix as its dylib load path, so every binary is
executable, first on `PATH`, and dies at the dynamic loader before `main`. Nexus committed to it
and never consulted `HAMLIB_SEARCH_DIRS`, which listed a working copy one directory later. CAT was
simply dead, with no diagnosis anywhere in the app.

This verifies the candidate actually runs before committing to it.

**A non-zero exit is a PASS here; only death by SIGNAL disqualifies.** Written as `status.success()`
it rejects wrapper scripts, version pins and this project's own `rigctld` stand-in in
`an_ordinary_connect_failure_carries_what_the_daemon_said` (answers `-vvv`, exits 9 otherwise) —
which would let Nexus's guess override a deliberate choice, the exact thing `resolve_rigctld`'s
contract forbids. An unloadable binary is killed by SIGABRT (exit 134), which is what separates the
two. Pinned by `runs_ok_accepts_a_nonzero_exit_and_rejects_only_a_signal`.

`cfg(unix)`, so this is not macOS-specific — a source-built Hamlib on Linux fails identically.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench / hardware — two Yaesu transceivers over Hamlib on macOS 26, with
  Hamlib 4.6.5 (Homebrew) and a source-built 4.7.0~rc under `~/.local` reproducing the fault.
- **Notes:** The failing case is a real installation, not a synthetic one: three `rigctld` binaries
  on `PATH`, the first of which cannot load its libraries. Test suite: 508 passed on this branch vs
  507 on `main`, one added test, no new failures. No on-air validation — this is CAT process
  selection, not waveform behaviour.

## Checklist

- [x] `cargo test` passes on the workspace (headless modem + engine + net + TempoDeep round-trips).
- [x] `cargo clippy --all-targets` is clean (no new warnings) — checked on the CI-pinned 1.93.1.
- [x] UI touched? No UI change in this PR.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
