### PR TITLE
Fix a test asserting a premise Hamlib does not honour

### DIFF
--- a/crates/tempo-audio/src/rig.rs
+++ b/crates/tempo-audio/src/rig.rs
@@ -1493,6 +1493,13 @@ mod tests {
         let (addr, _log) = mock_rigctld(|_l| "RPRT -1\n".to_string());
         let mut rig = Rig::rigctld(&addr);
         assert!(rig.ptt(true).is_err());
+        // TX-SAFETY INVARIANT, and the reason `ptt` sets this BEFORE the attempt: a key-down
+        // that ERRORED may still have keyed the rig, so we must believe we are keyed and let
+        // the unkey paths run. Believing the failure means never sending the unkey. This was
+        // pinned by an integration test that keyed a PTT-less rigctld dummy; that premise
+        // stopped holding at Hamlib 4.6.5 (the dummy now accepts PTT), so the assertion moved
+        // here, where it needs no daemon and cannot rot with a Hamlib release.
+        assert!(rig.keyed, "a FAILED key-down must still leave keyed=true");
     }
 
     #[test]

--- a/crates/tempo-audio/tests/rigctld_dummy.rs
+++ b/crates/tempo-audio/tests/rigctld_dummy.rs
@@ -278,25 +278,35 @@ fn failed_unkey_leaves_keyed_latched_for_the_retry_loop() {
 
 #[test]
 fn real_rprt_rejection_framing_parses_as_err() {
-    // set_mode must surface a rig rejection as Err so the radio loop's
-    // bounded retry can give up (never falsely advance last_mode). The dummy
-    // ACCEPTS unknown mode tokens (measured: `M NOSUCHMODE 0` → RPRT 0), so
-    // mode rejection stays mock territory — but a real negative RPRT is
-    // producible: `t` on a PTT-less daemon returns RPRT -11. Spawn a second
-    // daemon WITHOUT -P RIG and assert Rig surfaces the real error framing.
+    // A rig rejection must surface as Err so the radio loop's bounded retry can give up
+    // instead of falsely advancing its idea of the rig's state. Mock coverage cannot prove
+    // the FRAMING — that Rig actually parses a negative `RPRT n` off the wire — so this needs
+    // a real daemon that really rejects something.
+    //
+    // Finding one is the whole difficulty, because the dummy backend accepts almost
+    // everything. Measured against Hamlib 4.6.5 and 4.7.0~rc on 2026-08-13:
+    //
+    //   T 1 (no -P RIG)   → RPRT 0    t → 1, RPRT 0     M NOSUCHMODE 0 → RPRT 0
+    //   T 1 (-P NONE)     → RPRT 0    F 99999999999999  → RPRT 0
+    //   V NOSUCHVFO       → RPRT -1   G NOSUCHOP → RPRT -1   L NOSUCHLEVEL 1 → RPRT -11
+    //
+    // This test used to key PTT against a daemon spawned without `-P RIG`, on the belief that
+    // a PTT-less dummy rejects it. It does not (and the comment's own cited measurement was of
+    // `t`, not `T 1`) — so the test asserted `is_err()` on a command the daemon answers
+    // `RPRT 0`, and failed on any machine with a real rigctld rather than testing the framing.
+    // An unknown VFO is rejected for real, so drive the framing through that instead.
+    //
+    // The "a failed key-down still marks keyed" invariant that used to ride along here is not
+    // lost: it is a Rig state rule, not a wire-framing one, and is covered by the unit tests in
+    // `rig.rs` plus `failed_unkey_leaves_keyed_latched_for_the_retry_loop` above.
     let bin = require_rigctld!();
     let _serial = ONE_AT_A_TIME.lock().unwrap_or_else(|p| p.into_inner());
-    let d = DummyRig::spawn_with(&bin, &[]); // deliberately NO -P RIG
+    let d = DummyRig::spawn_with(&bin, &[]);
     let mut rig = connect_settled(&d.addr);
-    let err = rig.ptt(true);
     assert!(
-        err.is_err(),
-        "a real RPRT -1 from `T 1` must surface as Err, and the keyed flag \
-         semantics still apply (attempt marks keyed even on failure)"
-    );
-    assert!(
-        rig.keyed,
-        "a FAILED key-down still marks keyed (the rig may have keyed)"
+        rig.set_vfo("NOSUCHVFO").is_err(),
+        "a real negative RPRT (`V NOSUCHVFO` → RPRT -1) must surface as Err — if this passes as \
+         Ok the loop would treat a rejected command as applied"
     );
     // The connection must remain usable afterwards (drop-and-reconnect hygiene).
     assert_eq!(rig.read_freq().expect("post-error command"), 145_000_000);

--- a/crates/tempo-audio/tests/rigctld_dummy.rs
+++ b/crates/tempo-audio/tests/rigctld_dummy.rs
@@ -69,8 +69,11 @@ impl DummyRig {
     }
 
     /// Spawn with extra rigctld args prepended to the standard dummy set.
-    /// -P RIG matters: the dummy's caps default to PTT_NONE, so without it
-    /// every `T` returns RPRT -1 and `t` returns -11 (measured, Hamlib 4.5.5).
+    /// ⚠️ VERSION-DEPENDENT, and this file asserts the newer behaviour: on Hamlib
+    /// 4.5.5 a dummy without `-P RIG` rejected PTT (`T` → RPRT -1, `t` → -11), but
+    /// on 4.6.5 / 4.7.0~rc it ACCEPTS it (`T 1` → RPRT 0). Do not reintroduce a test
+    /// that keys a PTT-less dummy expecting a rejection — see the measurement table
+    /// on the rejection-framing test below.
     fn spawn_with(bin: &str, extra: &[&str]) -> DummyRig {
         // A port from the counter can still collide with an unrelated service
         // (measured once in 20 runs: rigctld exits 1 on a taken port). The


### PR DESCRIPTION
## Summary

`tests/rigctld_dummy.rs::real_rprt_rejection_framing_parses_as_err` asserts `is_err()` on a command
the daemon answers `RPRT 0`. It keys PTT against a dummy spawned without `-P RIG`, on the belief
that a PTT-less dummy rejects it. Measured against Hamlib 4.6.5 and 4.7.0~rc, `T 1` returns
`RPRT 0` with or without `-P RIG` or `-P NONE` — and the test's own cited measurement was of `t`,
not `T 1`. So it fails on any machine with a real `rigctld` installed, while never testing the
framing it is named for.

`V NOSUCHVFO` is rejected for real (`RPRT -1`), so this drives the same assertion through that.

The keyed-flag invariant that rode along is a `Rig` state rule rather than a wire-framing one, and
stays covered in `rig.rs` and by `failed_unkey_leaves_keyed_latched`.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench / hardware — Hamlib 4.6.5 and 4.7.0~rc on macOS 26.
- **Notes:** On current `main` this is the only failing test in `tempo-audio` on a machine with a
  real `rigctld` present: **507 passed, 1 failed**. With this patch: **508 passed, 0 failed**. If
  your CI hosts have no `rigctld` installed the test passes there vacuously, which is why it has
  gone unnoticed. No on-air validation applies.

## Checklist

- [x] `cargo test` passes on the workspace (headless modem + engine + net + TempoDeep round-trips).
- [x] `cargo clippy --all-targets` is clean (no new warnings) — checked on the CI-pinned 1.93.1.
- [x] UI touched? No UI change in this PR.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
