### PR TITLE
Use npm ci in build-linux.sh, as every CI job already does

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -87,7 +87,7 @@ if [ "$GUI" = 0 ]; then bold "Modem exes done (--no-gui)."; exit 0; fi
 
 # 3 — UI build deps ---------------------------------------------------------------------------
 bold "3/4  Web UI dependencies"
-( cd "$REPO/ui" && npm install >/dev/null )
+( cd "$REPO/ui" && npm ci >/dev/null )
 ok "ui/node_modules"
 
 # 4 — the GUI app + offline .deb + AppImage ---------------------------------------------------

--- a/scripts/build-windows-cross.sh
+++ b/scripts/build-windows-cross.sh
@@ -102,7 +102,7 @@ if [ "$GUI" = 1 ]; then
   command -v npm >/dev/null || die "npm not found — install Node.js LTS to build the UI."
   command -v makensis >/dev/null || warn "makensis not found — the NSIS step needs it (Debian/Ubuntu: sudo apt install nsis)."
   cargo tauri --version >/dev/null 2>&1 || { warn "installing tauri-cli…"; cargo install tauri-cli --version "^2" --locked; }
-  ( cd "$REPO/ui" && npm install >/dev/null )       # deps; cargo tauri runs the build
+  ( cd "$REPO/ui" && npm ci >/dev/null )            # deps; cargo tauri runs the build
   [ -f "$REPO/src-tauri/icons/icon.ico" ] || python3 "$REPO/scripts/gen-icons.py"
   bash "$REPO/scripts/fetch-hamlib.sh"              # bundle Hamlib for CAT (no-op if staged)
   # THE SILENT-LOBOTOMY GUARD. The DeepCW engine is a PAIR of gitignored files

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -103,7 +103,7 @@ if [ "$CHECK" = 1 ]; then bold "Toolchain OK (--check). Not building."; exit 0; 
 
 # 5 — Web UI deps + bundled Hamlib (for CAT) ---------------------------------
 bold "5/6  Web UI deps + Hamlib"
-npm --prefix "$REPO/ui" install
+npm --prefix "$REPO/ui" ci
 ok "ui dependencies installed (Tauri's beforeBuildCommand runs the build)"
 bash "$REPO/scripts/fetch-hamlib.sh"     # bundle rigctld so CAT needs no separate install
 ok "Hamlib staged (bundled into the installer)"


### PR DESCRIPTION
## Summary

`scripts/build-linux.sh` uses `npm install`, which rewrites `ui/package-lock.json`: npm 11.9.0
strips the `libc` (glibc/musl) fields from the optional Linux rollup and esbuild binaries, which is
npm's own selector for which native binary a Linux box installs. Every `ci.yml` and `release.yml`
job already runs `npm --prefix ui ci`; the build script did not, so a local build left the lockfile
dirty and subtly wrong for Linux consumers.

`scripts/build-windows.sh` does not invoke npm, so it needs no change.

One line.

## Linked issue

Refs #6

## Validation

- **Validated against:** Static — the script's syntax (`bash -n`) and the lockfile diff that
  `npm install` produces under npm 11.9.0.
- **Notes:** I have **not** run a full Linux build; I do not have a Linux host for this. The claim
  is limited to what the one-line change does and to matching what your own CI already does. If you
  would rather verify it on a Linux box before taking it, that is entirely reasonable.

## Checklist

- [x] `cargo test` passes on the workspace (headless modem + engine + net + TempoDeep round-trips).
- [x] `cargo clippy --all-targets` is clean (no new warnings) — checked on the CI-pinned 1.93.1.
- [x] UI touched? No UI change in this PR.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
