### PR TITLE
Name the branch and fork in the build stamp, not just the commit

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -6,16 +6,33 @@ import { execSync } from 'node:child_process'
 // build is running — the product version string is always "0.2.0", which made it impossible
 // to tell whether a fresh install actually took. Displayed in Settings.
 function buildId(): string {
-  let hash = 'local'
-  try {
-    hash = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
-      .toString()
-      .trim()
-  } catch {
-    /* not a git checkout — leave "local" */
+  const git = (args: string): string | null => {
+    try {
+      const out = execSync(`git ${args}`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+      return out.length > 0 ? out : null
+    } catch {
+      return null
+    }
   }
+
+  const hash = git('rev-parse --short HEAD') ?? 'local'
+  // Branch and fork matter as much as the hash once anyone builds from a fork or a
+  // topic branch: two builds of different branches at the same commit-less version
+  // are otherwise indistinguishable, and "which branch is this?" is the first
+  // question asked of a bug report from a self-built binary.
+  const branch = git('rev-parse --abbrev-ref HEAD') ?? 'detached'
+  const repo = (() => {
+    const url = git('remote get-url origin')
+    if (!url) return null
+    const tail = url.replace(/\.git$/, '').replace(/\/$/, '').split(/[/:]/).slice(-2)
+    return tail.length === 2 ? tail.join('/') : null
+  })()
+  // A working tree with uncommitted changes is NOT the commit it names.
+  const dirty = git('status --porcelain') ? '-dirty' : ''
+
   const now = new Date().toISOString().slice(0, 16).replace('T', ' ')
-  return `${now}Z · ${hash}`
+  const where = repo ? `${repo} ${branch}` : branch
+  return `${now}Z · ${where}@${hash}${dirty}`
 }
 
 // https://vite.dev/config/

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -20,7 +20,15 @@ function buildId(): string {
   // topic branch: two builds of different branches at the same commit-less version
   // are otherwise indistinguishable, and "which branch is this?" is the first
   // question asked of a bug report from a self-built binary.
-  const branch = git('rev-parse --abbrev-ref HEAD') ?? 'detached'
+  // ⚠️ NOT `rev-parse --abbrev-ref HEAD`: on a DETACHED head that prints the literal
+  // string "HEAD" and exits 0, so a `?? 'detached'` fallback is unreachable (measured).
+  // release.yml triggers on `tags: ['v*']` and actions/checkout leaves HEAD detached, so
+  // every published release would have named its branch "HEAD" — the exact field this
+  // stamp exists to add. `symbolic-ref --short` exits 128 with empty output when detached,
+  // so the helper's null path fires. A tag build names its tag, which is what you want on
+  // a release artifact.
+  const branch =
+    git('describe --tags --exact-match HEAD') ?? git('symbolic-ref --short HEAD') ?? 'detached'
   const repo = (() => {
     const url = git('remote get-url origin')
     if (!url) return null
@@ -28,7 +36,10 @@ function buildId(): string {
     return tail.length === 2 ? tail.join('/') : null
   })()
   // A working tree with uncommitted changes is NOT the commit it names.
-  const dirty = git('status --porcelain') ? '-dirty' : ''
+  // Tracked source only. `status --porcelain` counts refreshed data resources and any
+  // untracked scratch file, and this repo's checkout is shared by several agents — an
+  // unconditional probe leaves `-dirty` permanently on, which stops it being a signal.
+  const dirty = git('status --porcelain --untracked-files=no') ? '-dirty' : ''
 
   const now = new Date().toISOString().slice(0, 16).replace('T', ' ')
   const where = repo ? `${repo} ${branch}` : branch


### PR DESCRIPTION
## Summary

`__BUILD_ID__` already answers "did this install actually take", with a timestamp and a short
hash. That is the hard part and is unchanged here. What it cannot answer is **which branch this
is** — and that is the first question asked of a bug report from a self-built binary, because
anyone building from source is usually on a topic branch or a fork, and two builds of different
branches at the same commit look identical in every other surface the app exposes.

So the stamp gains the origin repo, the branch, and a `-dirty` marker:

```
2026-08-14 11:06Z · kd9taw/Nexus main@f90be28c
2026-08-14 11:06Z · someone/Nexus fix-cat@1234abc-dirty
```

`-dirty` earns its place on its own: a working tree with uncommitted changes is **not** the commit
it names, and a stamp that quietly claims otherwise is worse than no stamp.

Every probe degrades independently rather than failing the build — no git at all (a source
tarball) still stamps `local`, no remote drops the repo prefix, a detached HEAD reads `detached`.
The existing try/catch behaviour is preserved: this is a build-time nicety and must never be the
reason a build fails.

One file, and it stays inside the mechanism you already have.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench — built the UI and read the emitted constant back out of the
  bundle, including the `-dirty` case.
- **Notes:** Build-time string only; no runtime, waveform or on-air behaviour is involved, and
  nothing here was validated on the air.

## Checklist

- [x] `cargo test` passes on the workspace — no Rust change in this PR.
- [x] `cargo clippy --all-targets` is clean — no Rust change in this PR.
- [x] UI touched? Yes — `npm --prefix ui run build` (`tsc -b && vite build`) passes.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
