### PR TITLE
Make the UI suite survive Node 25's built-in localStorage

### DIFF
--- a/ui/src/test-setup.ts
+++ b/ui/src/test-setup.ts
@@ -1,0 +1,98 @@
+/** Vitest setup — runs before every test file.
+ *
+ * WHY THIS EXISTS. Node 25 ships a built-in `localStorage` global. It is only functional
+ * when the process was started with a valid `--localstorage-file`; without one, Node
+ * warns ("`--localstorage-file` was provided without a valid path") and leaves an object
+ * that has no `clear()`. Because that global already exists, jsdom never installs its own
+ * over it — measured inside a jsdom test on Node 25.6.1:
+ *
+ *     window === globalThis = true
+ *     globalThis.localStorage = object, .clear = undefined, constructor = undefined
+ *     window.localStorage === globalThis.localStorage = true
+ *
+ * So every suite that resets storage between cases dies in `beforeEach` with
+ * "localStorage.clear is not a function": 44 test files and 537 tests on this project,
+ * all green on Node 23.11.0 with no code change. The suite's result was a function of
+ * the Node minor rather than of the code under test, and the message names storage
+ * rather than the version, so it reads as a real regression.
+ *
+ * WHY NOT PIN THE TOOLCHAIN AWAY FROM NODE 25. An `engines` range with `engine-strict`
+ * makes EVERY transitive dependency's range blocking too — on this dependency tree that
+ * also refuses Node 23, a version that runs the suite green (`@asamuzakjp/css-color`
+ * wants `^20.19.0 || ^22.12.0 || >=24.0.0`). Banning a working version to block a broken
+ * one is the wrong trade.
+ *
+ * WHY NOT RESTORE JSDOM'S. There is nothing to restore: jsdom's implementation was never
+ * installed, because the global was already occupied. The only fix is to supply one.
+ *
+ * Deliberately narrow: it replaces a storage global ONLY when that global cannot `clear()`.
+ * On Node <= 24, jsdom's own storage is present and functional, and this is a no-op.
+ */
+
+/** A minimal `Storage` that matches the SHAPE of the real one, not merely its methods.
+ *
+ *  The distinction is load-bearing and was found by test, not by reading the spec: a
+ *  real `Storage` keeps `getItem`/`setItem`/`clear`/… on `Storage.prototype` and exposes
+ *  each STORED KEY as an own enumerable property, so `Object.keys(localStorage)` returns
+ *  the keys an operator's settings live under. Building this as an object literal put the
+ *  methods on the instance instead, and `Object.keys()` then answered
+ *  `['clear','getItem','key','length','removeItem','setItem']` — which is exactly what
+ *  `windowScope.test.ts` diffs to prove one surface cannot overwrite another's keys.
+ *
+ *  So: methods on the prototype (class), entries mirrored as own enumerable properties.
+ *  Property WRITES (`localStorage.foo = 'x'`) are still not intercepted — that would need
+ *  a Proxy, nothing in this suite does it, and a Proxy would hide real failures. */
+class MemoryStorage {
+  #map = new Map<string, string>()
+
+  get length(): number {
+    return this.#map.size
+  }
+
+  clear(): void {
+    for (const k of this.#map.keys()) delete (this as unknown as Record<string, unknown>)[k]
+    this.#map.clear()
+  }
+
+  getItem(key: string): string | null {
+    const k = String(key)
+    return this.#map.has(k) ? (this.#map.get(k) as string) : null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.#map.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    const k = String(key)
+    this.#map.delete(k)
+    delete (this as unknown as Record<string, unknown>)[k]
+  }
+
+  setItem(key: string, value: string): void {
+    const k = String(key)
+    const v = String(value)
+    this.#map.set(k, v)
+    Object.defineProperty(this, k, {
+      value: v,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+  }
+}
+
+function memoryStorage(): Storage {
+  return new MemoryStorage() as unknown as Storage
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  const current = (globalThis as unknown as Record<string, Storage | undefined>)[name]
+  if (!current || typeof current.clear !== 'function') {
+    Object.defineProperty(globalThis, name, {
+      value: memoryStorage(),
+      configurable: true,
+      writable: true,
+    })
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
     port: 5173,
     host: true,
   },
+  // Vitest: see src/test-setup.ts — Node 25's built-in `localStorage` shadows jsdom's
+  // and breaks every suite that clears storage between cases.
+  test: {
+    setupFiles: ['./src/test-setup.ts'],
+  },
   build: {
     outDir: 'dist',
     sourcemap: false,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,4 +1,7 @@
-import { defineConfig } from 'vite'
+// `vitest/config` re-exports Vite's defineConfig with the `test` key added to the type.
+// Importing it from 'vite' typechecks everything EXCEPT `test`, so `tsc -b` fails with
+// TS2769 — and `npm run build` is `tsc -b && vite build`, which four CI jobs run.
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { execSync } from 'node:child_process'
 


### PR DESCRIPTION
## Summary

On Node 25 the whole jsdom suite dies: **44 test files, 537 tests**, every one in `beforeEach`
with `localStorage.clear is not a function`. All of them pass on Node 23.11.0 with no code change,
so the suite's result was a function of the Node minor rather than of the code under test — and
the message names storage rather than the version, so it reads as a real regression. **CI pins
Node 24 and is unaffected**, which is exactly why this can sit unnoticed while it breaks local runs.

Node 25 ships a built-in `localStorage` global that is only functional when the process got a valid
`--localstorage-file`; without one Node warns and leaves an object with no `clear()`. Because the
global already exists, **jsdom never installs its own over it**. Measured inside a jsdom test on
25.6.1:

```
window === globalThis                          = true
globalThis.localStorage.clear                   = undefined
window.localStorage === globalThis.localStorage = true
constructor                                     = undefined
```

So there is nothing to restore — the fix has to *supply* a Storage. A setup file replaces a storage
global only when that global cannot `clear()`, which is a no-op on Node ≤ 24 where jsdom's own is
present and working.

The replacement matches the **shape** of a real `Storage`, not merely its methods, and that
distinction was found by test rather than by reading the spec: a real `Storage` keeps its methods on
`Storage.prototype` and exposes each stored key as an own enumerable property, so
`Object.keys(localStorage)` returns the keys. Built as an object literal it answered
`['clear','getItem','key','length','removeItem','setItem']` instead — which is precisely what
`windowScope.test.ts` diffs to prove one surface cannot overwrite another's keys.

**Not done by pinning the toolchain away from Node 25.** An `engines` range with `engine-strict`
makes every *transitive* dependency's range blocking too, and on this tree that also refuses Node 23
(`@asamuzakjp/css-color` wants `^20.19.0 || ^22.12.0 || >=24.0.0`) — a version that runs the suite
green. Banning a working version to block a broken one seemed the wrong trade.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench — the full UI suite on two Node versions.
- **Notes:** **3130 passed / 0 failed across 245 files on Node 25.6.1 AND on Node 23.11.0.** The
  intermediate object-literal version reached 3128/2 and looked finished on a four-file subset;
  only the full suite exposed the last two, so the subset result is not the one to trust. No on-air
  validation applies — test infrastructure only.

## Checklist

- [x] `cargo test` passes on the workspace — no Rust change in this PR.
- [x] `cargo clippy --all-targets` is clean — no Rust change in this PR.
- [x] UI touched? Yes — `npm --prefix ui run build` (`tsc -b && vite build`) passes.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
