### PR TITLE
Derive the SettingsPanel api mock from the real module, not a hand-kept list

### DIFF
--- a/ui/src/components/SettingsPanel.aprsplacement.test.tsx
+++ b/ui/src/components/SettingsPanel.aprsplacement.test.tsx
@@ -15,32 +15,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.audiodevices.test.tsx
+++ b/ui/src/components/SettingsPanel.audiodevices.test.tsx
@@ -24,32 +24,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
-    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
-    'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.backup.test.tsx
+++ b/ui/src/components/SettingsPanel.backup.test.tsx
@@ -16,32 +16,26 @@ import defaultSettings from './__fixtures__/defaultSettings.json'
 const api = vi.hoisted(() => {
   // SettingsPanel pulls ~50 verbs from ../api. They all resolve null, which is enough for a
   // mount — the assertions here are about WHICH save verb gets called, not what it returns.
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.connhealth.test.tsx
+++ b/ui/src/components/SettingsPanel.connhealth.test.tsx
@@ -20,32 +20,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt',
-    'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.cwkeyer.test.tsx
+++ b/ui/src/components/SettingsPanel.cwkeyer.test.tsx
@@ -17,32 +17,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
-    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
-    'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.deeplink.test.tsx
+++ b/ui/src/components/SettingsPanel.deeplink.test.tsx
@@ -23,32 +23,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt',
-    'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.lotwupload.test.tsx
+++ b/ui/src/components/SettingsPanel.lotwupload.test.tsx
@@ -26,32 +26,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt',
-    'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.moderouting.test.tsx
+++ b/ui/src/components/SettingsPanel.moderouting.test.tsx
@@ -17,33 +17,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-    'setRoutingRules', 'setDefaultRadio', 'routePreview',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.n1mm.test.tsx
+++ b/ui/src/components/SettingsPanel.n1mm.test.tsx
@@ -12,32 +12,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.orbital.test.tsx
+++ b/ui/src/components/SettingsPanel.orbital.test.tsx
@@ -22,32 +22,26 @@ import type { TleStatus } from '../api'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
-    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
-    'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.radiorouting.test.tsx
+++ b/ui/src/components/SettingsPanel.radiorouting.test.tsx
@@ -15,32 +15,26 @@ import defaultSettings from './__fixtures__/defaultSettings.json'
 const api = vi.hoisted(() => {
   // SettingsPanel pulls ~50 verbs from ../api. They all resolve null, which is enough for a
   // mount — the assertions here are about WHICH save verb gets called, not what it returns.
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.rigpicker.test.tsx
+++ b/ui/src/components/SettingsPanel.rigpicker.test.tsx
@@ -31,32 +31,26 @@ import defaultSettings from './__fixtures__/defaultSettings.json'
 import hamlibSerialSpeeds from './__fixtures__/hamlibSerialSpeeds.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
-    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
-    'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.rigshare.test.tsx
+++ b/ui/src/components/SettingsPanel.rigshare.test.tsx
@@ -21,32 +21,26 @@ import defaultSettings from './__fixtures__/defaultSettings.json'
 const api = vi.hoisted(() => {
   // SettingsPanel pulls ~50 verbs from ../api. They all resolve null, which is enough for a
   // mount — the assertions here are about WHICH save verb gets called, not what it returns.
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.satdoppler.test.tsx
+++ b/ui/src/components/SettingsPanel.satdoppler.test.tsx
@@ -16,32 +16,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode', 'confirmSatUplink',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.search.test.tsx
+++ b/ui/src/components/SettingsPanel.search.test.tsx
@@ -17,32 +17,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt',
-    'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.sstvplacement.test.tsx
+++ b/ui/src/components/SettingsPanel.sstvplacement.test.tsx
@@ -14,32 +14,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex', 'civDiagnosticLog', 'civDiagnosticStatus',
-    'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion', 'getSpectrumRow', 'setFrequency',
-    'getWatchlist', 'setWatchlist', 'openPanelWindow', 'getAssistanceJournal',
-    'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.thetiscat.test.tsx
+++ b/ui/src/components/SettingsPanel.thetiscat.test.tsx
@@ -13,32 +13,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
-    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
-    'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({

--- a/ui/src/components/SettingsPanel.txlevel.test.tsx
+++ b/ui/src/components/SettingsPanel.txlevel.test.tsx
@@ -22,32 +22,26 @@ import type { FeaturesApi } from '../useFeatures'
 import defaultSettings from './__fixtures__/defaultSettings.json'
 
 const api = vi.hoisted(() => {
-  const VERBS = [
-    'clearCloudlogKey', 'clearClublogPassword', 'clearEqslPassword', 'clearHamqthPassword',
-    'clearHrdlogCode', 'clearLotwPassword', 'clearQrzLogbookKey', 'clearQrzPassword', 'detectRigs',
-    'downloadEqslReport', 'downloadLotwReport', 'getAllRigModels', 'getAudioDevices', 'getBandPlan',
-    'getRigModels', 'getSerialPortsDetailed', 'getSettings', 'setCloudlogKey', 'setClublogPassword',
-    'setEqslPassword', 'setHamqthPassword', 'setHrdlogCode', 'setLotwPassword', 'setQrzLogbookKey',
-    'setQrzPassword', 'setRepeaterbookToken', 'setRxGain', 'setSettings', 'setTxLevel', 'addRadio',
-    'removeRadio', 'renameRadio', 'setActiveRadio', 'setRadioBands', 'updateRadioProfile', 'testCat',
-    'probeCatPorts', 'qrzTestConnection', 'syncQrz', 'n3fjpTestConnection', 'getConnectionLog',
-    'getCredentialsStatus', 'fetchLotwUsers', 'getLotwUsersStatus', 'fetchFccStates',
-    'getFccStatesStatus', 'getTleStatus', 'fetchTlesNow', 'importTles', 'discoverFlex',
-    'civDiagnosticLog', 'civDiagnosticStatus', 'allTxtLocation', 'revealAllTxt', 'recordingsLocation', 'revealRecordings', 'appVersion',
-    'getSpectrumRow', 'setFrequency', 'getWatchlist', 'setWatchlist', 'openPanelWindow',
-    'getAssistanceJournal', 'setUnassistedMode',
-  ]
   const spies: Record<string, ReturnType<typeof vi.fn>> = {}
   const get = (name: string) => {
     if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
     return spies[name]
   }
-  return { spies, get, VERBS }
+  return { spies, get }
 })
 
-vi.mock('../api', () => {
+// Mock EVERY export of `../api`, derived from the real module rather than a hand-kept list.
+//
+// The list was the problem: a verb missing from it made the panel THROW ON MOUNT ("No export is
+// defined on the mock"), which presents as a behaviour regression in whichever test happened to
+// run -- not as the out-of-date mock it actually is. Reading the real module's export names makes
+// that failure impossible by construction.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   const mod: Record<string, unknown> = {}
-  for (const v of api.VERBS) mod[v] = api.get(v)
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
   return mod
 })
 vi.mock('../toast', () => ({


### PR DESCRIPTION
## Summary

All 18 `SettingsPanel.*.test.tsx` files mock `../api` from a literal `VERBS` array naming every
export the panel might call. **The array is the defect.** A verb missing from it does not fail an
assertion — it makes the panel **throw on mount** with `No export is defined on the mock`, so an
out-of-date mock presents as a behaviour regression in whichever test happened to run, and the
message points at the panel rather than at the list.

Adding one api verb therefore costs an 18-file edit, and forgetting produces a failure that looks
like something else entirely.

Deriving the mock from the real module's own exports removes the class by construction:

```ts
vi.mock('../api', async (importOriginal) => {
  const actual = await importOriginal<Record<string, unknown>>()
  const mod: Record<string, unknown> = {}
  for (const name of Object.keys(actual)) {
    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
  }
  return mod
})
```

A verb added to `api.ts` is mocked the moment it exists, and no list can drift. Non-function exports
pass through unchanged. Net −109 lines.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench — the full UI suite, plus a purpose-built control.
- **Notes:** The 18 files pass (161 tests). **The control is the part worth trusting:** adding a new
  export to `api.ts` confirms the derived mock exposes it, while a hand-kept list does not — which is
  exactly the failure being removed, tested in both directions rather than only the happy one.
  Full suite: **3130 passed / 0 failed across 245 files on Node 23.11.0**. On Node 25 the suite fails
  for an unrelated reason (Node's built-in `localStorage` global shadowing jsdom's), so Node 25 is not
  a clean signal on this branch — that is fixed separately in the companion PR. No on-air validation
  applies; this is test infrastructure only.

## Checklist

- [x] `cargo test` passes on the workspace — no Rust change in this PR.
- [x] `cargo clippy --all-targets` is clean — no Rust change in this PR.
- [x] UI touched? Yes — `tsc -b` passes (exit 0); test files only, no shipped code.
- [x] Docs updated where relevant — the reasoning is in the code comments and commit message.
- [x] **Validation honesty:** I have stated below what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
