### PR TITLE
Check the rig form before saving it, not after it behaves like broken hardware

### DIFF
--- a/crates/tempo-audio/src/rigmodels.rs
+++ b/crates/tempo-audio/src/rigmodels.rs
@@ -296,11 +296,33 @@ pub fn rig_model_name(model: u32) -> Option<&'static str> {
 ///
 /// (Hamlib's Dummy/NET/FLRig — models ≤ 4 — are excluded by `match_rig_model` separately;
 /// they are not radios at all rather than software-served ones.)
-pub(crate) fn is_software_cat_profile(model: u32) -> bool {
+pub fn is_software_cat_profile(model: u32) -> bool {
     matches!(
         model,
         5 | 7 | 2036 | 2040 | 2048 | 2051 | 2054 | 2056 | 23005
     )
+}
+
+/// Every catalog model that does **not** need a serial port: the software-CAT profiles above,
+/// plus Hamlib's Dummy/NET/FLRig (≤ 4). This is the same rule
+/// [`crate::usbrig::probe_usb_rigs`] gates on — `model <= 4 || is_software_cat_profile(model)`,
+/// there written as a `continue` because there is no USB device to enumerate.
+///
+/// It exists as a LIST rather than a predicate because its one other consumer is the settings
+/// UI, across the Tauri boundary, and a per-keystroke round trip to ask about one model would
+/// be absurd. The UI asks once and holds the set.
+///
+/// **Why the UI must not keep its own copy.** The membership above is not stable: `2040` was
+/// promoted out of the extended tier in the very commit that made these profiles start
+/// matching USB hardware, and the doc above keeps `7` against settings files written before it
+/// was delisted. A hand-maintained TypeScript duplicate would be correct on the day it was
+/// written and wrong at the next tier move — silently, and in the direction that blocks an
+/// operator from saving a configuration that is in fact fine.
+pub fn portless_rig_models() -> Vec<u32> {
+    // 0..=4 is Hamlib's own low range (0 None/VOX, 1 Dummy, 2 NET rigctl, 4 FLRig).
+    (0..=4)
+        .chain([5, 7, 2036, 2040, 2048, 2051, 2054, 2056, 23005])
+        .collect()
 }
 
 /// Recognise a CAT server that **names itself** in the greeting it sends on connect, and
@@ -529,6 +551,30 @@ pub fn native_spectrum_kind(model: u32, rig_conn: &str) -> Option<SpectrumKind> 
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    /// `portless_rig_models` is a materialised copy of a rule that lives as a predicate, handed
+    /// across the Tauri boundary because the UI cannot call the predicate per keystroke. Two
+    /// spellings of one rule drift — so this sweeps the whole catalog range and demands they
+    /// agree exactly, in BOTH directions: a model added to `is_software_cat_profile` without the
+    /// list fails here, and so does a stale entry left in the list after a tier move.
+    #[test]
+    fn the_portless_list_and_the_portless_rule_are_the_same_set() {
+        let listed: HashSet<u32> = portless_rig_models().into_iter().collect();
+        for model in 0u32..30_000 {
+            let by_rule = model <= 4 || is_software_cat_profile(model);
+            assert_eq!(
+                listed.contains(&model),
+                by_rule,
+                "model {model}: list says {}, rule says {by_rule}",
+                listed.contains(&model)
+            );
+        }
+        // Positive control: the sweep above passes vacuously if the rule ever answered `false`
+        // everywhere, which is exactly the shape a refactor accident takes. Name two members.
+        assert!(listed.contains(&2054), "Thetis (2054) must be portless");
+        assert!(listed.contains(&4), "FLRig (4) must be portless");
+        assert!(!listed.contains(&1042), "a real rig (FTDX10) needs a port");
+    }
 
     /// THE GROUND TRUTH the satellite refusal is worded from, pinned across the
     /// crate boundary.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9656,6 +9656,26 @@ fn get_all_rig_models() -> Vec<(u32, String)> {
     }
 }
 
+/// The models that need NO serial port — Hamlib's Dummy/NET/FLRig plus the software-CAT
+/// profiles (Thetis, PowerSDR, SmartSDR, …). See
+/// [`tempo_audio::rigmodels::portless_rig_models`] for why this crosses the boundary as a list
+/// and why the UI must not keep a copy of its own.
+///
+/// An empty result means "could not be determined" (built without the `radio` feature). The
+/// settings form treats that as unknown and declines to BLOCK a save on it: a rule that cannot
+/// be read must never be the reason an operator cannot save a configuration that is fine.
+#[tauri::command]
+fn get_portless_rig_models() -> Vec<u32> {
+    #[cfg(feature = "radio")]
+    {
+        tempo_audio::rigmodels::portless_rig_models()
+    }
+    #[cfg(not(feature = "radio"))]
+    {
+        Vec::new()
+    }
+}
+
 /// Tempo's proposed calling-frequency band plan (HF + VHF/UHF), for the band
 /// selector. Each entry is General-legal + clear of the existing watering holes.
 #[tauri::command(async)]
@@ -16314,6 +16334,7 @@ pub fn run() {
             sstv_stop,
             get_rig_models,
             get_all_rig_models,
+            get_portless_rig_models,
             get_band_plan,
             set_license_class,
             get_licensed_band_plan,

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1919,6 +1919,14 @@ export async function getAllRigModels(): Promise<[number, string][]> {
   return invoke<[number, string][]>('get_all_rig_models')
 }
 
+/** Models that need NO serial port — Dummy/NET/FLRig and the software-CAT profiles.
+ *  The rule lives in Rust (`rigmodels::portless_rig_models`) and is fetched rather than
+ *  duplicated here: its membership has changed before, and a stale copy would block saves that
+ *  are in fact correct. An empty array means the rule could not be read. */
+export async function getPortlessRigModels(): Promise<number[]> {
+  return invoke<number[]>('get_portless_rig_models')
+}
+
 /** Zero-config: scan connected USB radios → suggested model + port + paired audio. */
 export async function detectRigs(): Promise<DetectedRig[]> {
   return invoke<DetectedRig[]>('detect_rigs')

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { SAT_VFO_MAPS } from '../features/satVfo'
+import { checkRigForm, blocks, type RigCheck } from '../rigFormChecks'
 import {
   confirmSatUplink,
   exportSettingsBundle,
@@ -588,6 +589,8 @@ export function SettingsPanel({
   // (0.9.6 design rule), so searchability arrives as a filter field that narrows the options.
   const [rigFilter, setRigFilter] = useState('')
   const [serialPorts, setSerialPorts] = useState<string[]>([])
+  /** Findings from the last save attempt — warnings stay visible after a save that proceeded. */
+  const [rigChecks, setRigChecks] = useState<RigCheck[]>([])
   // Port -> USB product label ("USB-Enhanced-SERIAL-B CH342"), so the picker can tell a
   // dual-serial rig's two interfaces apart (Xiegu CAT is on SERIAL-B).
   const [portLabels, setPortLabels] = useState<Record<string, string>>({})
@@ -1907,6 +1910,20 @@ export function SettingsPanel({
       // silently-greyed Save button with a context-free "required" error.
       setTab('station')
       setError('Enter your callsign on the Station tab before saving.')
+      return
+    }
+    // Check the RADIO before saving it. Until now the callsign was the only validated field, so
+    // every way of getting the rig wrong saved silently and then behaved like broken hardware —
+    // the symptom always shows up far from the cause. Errors block and name the fix; warnings are
+    // stated and the operator proceeds, because an unusual-but-correct station must never be
+    // locked out of its own configuration by a heuristic.
+    const rigProblems = checkRigForm(form, serialPorts, editingRadioId)
+    setRigChecks(rigProblems)
+    if (blocks(rigProblems)) {
+      setTab('radio')
+      setError(
+        rigProblems.find((c) => c.level === 'error')?.message ?? 'Check the radio settings.',
+      )
       return
     }
     setStatus('saving')
@@ -8474,6 +8491,16 @@ export function SettingsPanel({
         </div>
 
         <div className="settings-actions">
+          {/* Warnings from the last save. They did NOT block it -- the save went through -- so
+              they are stated once and left visible rather than interrupting. An operator whose
+              setup is unusual but correct must be able to read them and carry on. */}
+          {rigChecks
+            .filter((c) => c.level === 'warning')
+            .map((c) => (
+              <span className="settings-warn" role="status" key={c.message}>
+                {c.message}
+              </span>
+            ))}
           {error && <span className="settings-error" role="alert">{error}</span>}
           {status === 'saved' && !error && (
             <span className="settings-ok" role="status">Saved</span>

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -31,6 +31,7 @@ import {
   downloadEqslReport,
   downloadLotwReport,
   getAllRigModels,
+  getPortlessRigModels,
   getAudioDevices,
   getBandPlan,
   getRigModels,
@@ -591,6 +592,8 @@ export function SettingsPanel({
   const [serialPorts, setSerialPorts] = useState<string[]>([])
   /** Findings from the last save attempt — warnings stay visible after a save that proceeded. */
   const [rigChecks, setRigChecks] = useState<RigCheck[]>([])
+  /** Models needing no serial port, from the backend. Empty = rule unread; see checkRigForm. */
+  const [portlessRigModels, setPortlessRigModels] = useState<number[]>([])
   // Port -> USB product label ("USB-Enhanced-SERIAL-B CH342"), so the picker can tell a
   // dual-serial rig's two interfaces apart (Xiegu CAT is on SERIAL-B).
   const [portLabels, setPortLabels] = useState<Record<string, string>>({})
@@ -838,6 +841,11 @@ export function SettingsPanel({
       .catch(() => mounted && setStatus('idle'))
     getRigModels()
       .then((m) => mounted && setRigModels(m))
+      .catch(() => {})
+    // The backend's own "needs no serial port" rule, fetched once. On failure it stays empty and
+    // the pre-save port check declines to block — see checkRigForm.
+    getPortlessRigModels()
+      .then((m) => mounted && Array.isArray(m) && setPortlessRigModels(m))
       .catch(() => {})
     getSerialPortsDetailed()
       .then((infos) => mounted && applyPorts(infos))
@@ -1926,7 +1934,7 @@ export function SettingsPanel({
     // the symptom always shows up far from the cause. Errors block and name the fix; warnings are
     // stated and the operator proceeds, because an unusual-but-correct station must never be
     // locked out of its own configuration by a heuristic.
-    const rigProblems = checkRigForm(form, serialPorts, editingRadioId)
+    const rigProblems = checkRigForm(form, serialPorts, portlessRigModels)
     setRigChecks(rigProblems)
     if (blocks(rigProblems)) {
       setTab('radio')

--- a/ui/src/rigFormChecks.test.ts
+++ b/ui/src/rigFormChecks.test.ts
@@ -1,0 +1,82 @@
+// Pre-save rig checks. Each case here is a mistake that saves silently today and then presents as
+// broken hardware — the symptom always appears far from the cause, which is why they are worth
+// catching at the one moment the operator is looking at the setting.
+import { describe, it, expect } from 'vitest'
+import { checkRigForm, blocks, type RigFormFacts } from './rigFormChecks'
+
+const PORTS = ['/dev/cu.usbserial-A', '/dev/tty.usbserial-A', 'COM5']
+
+const form = (over: Partial<RigFormFacts> = {}): RigFormFacts => ({
+  serialPort: '/dev/cu.usbserial-A',
+  rigConn: 'serial',
+  pttMethod: 'cat',
+  rigModel: 1049,
+  radios: [{ id: 0, name: 'FT-710', serialPort: '/dev/cu.usbserial-A' }],
+  activeRadio: 0,
+  ...over,
+})
+
+describe('checkRigForm', () => {
+  it('passes a correct setup silently', () => {
+    expect(checkRigForm(form(), PORTS, 0)).toEqual([])
+  })
+
+  it('ignores a network rig entirely — it has no serial port to be wrong about', () => {
+    const checks = checkRigForm(form({ rigConn: 'network', serialPort: '' }), PORTS, 0)
+    expect(checks).toEqual([])
+  })
+
+  it('blocks a rig model with no port — CAT cannot work without one', () => {
+    const checks = checkRigForm(form({ serialPort: '' }), PORTS, 0)
+    expect(blocks(checks)).toBe(true)
+    expect(checks[0].message).toMatch(/no serial port/i)
+  })
+
+  it('allows no port when there is no rig model either — that is VOX, not a mistake', () => {
+    const checks = checkRigForm(
+      form({ serialPort: '', rigModel: 0, pttMethod: 'vox' }),
+      PORTS,
+      0,
+    )
+    expect(checks).toEqual([])
+  })
+
+  it('blocks a /dev/tty.* port, which hangs on carrier instead of failing', () => {
+    const checks = checkRigForm(form({ serialPort: '/dev/tty.usbserial-A' }), PORTS, 0)
+    expect(blocks(checks)).toBe(true)
+    expect(checks.some((c) => /dial-in device/.test(c.message))).toBe(true)
+  })
+
+  it('blocks two radios sharing one CAT port', () => {
+    const checks = checkRigForm(
+      form({
+        radios: [
+          { id: 0, name: 'FT-710', serialPort: '/dev/cu.usbserial-A' },
+          { id: 1, name: 'FTX-1', serialPort: '/dev/cu.usbserial-A' },
+        ],
+      }),
+      PORTS,
+      1, // editing the FTX-1: the clash is with the OTHER radio
+    )
+    expect(blocks(checks)).toBe(true)
+    expect(checks.some((c) => /FT-710 already uses/.test(c.message))).toBe(true)
+  })
+
+  it('does not accuse a radio of clashing with itself', () => {
+    // The radio being edited already holds this port — that is the normal case, not a clash.
+    expect(checkRigForm(form(), PORTS, 0)).toEqual([])
+  })
+
+  it('blocks PTT over CAT with no rig model — nothing to send the keying command to', () => {
+    const checks = checkRigForm(form({ rigModel: 0, pttMethod: 'cat' }), PORTS, 0)
+    expect(blocks(checks)).toBe(true)
+    expect(checks.some((c) => /PTT is set to CAT/.test(c.message))).toBe(true)
+  })
+
+  it('warns, but does NOT block, when the port is simply not plugged in right now', () => {
+    const checks = checkRigForm(form({ serialPort: 'COM9' }), PORTS, 0)
+    expect(blocks(checks)).toBe(false)
+    expect(checks[0].level).toBe('warning')
+    expect(checks[0].message).toMatch(/not connected right now/)
+  })
+})

--- a/ui/src/rigFormChecks.test.ts
+++ b/ui/src/rigFormChecks.test.ts
@@ -6,28 +6,30 @@ import { checkRigForm, blocks, type RigFormFacts } from './rigFormChecks'
 
 const PORTS = ['/dev/cu.usbserial-A', '/dev/tty.usbserial-A', 'COM5']
 
+// A stand-in for `getPortlessRigModels()`: Hamlib's low range plus two software-CAT profiles.
+// The real list comes from Rust, where `rigmodels.rs` pins it against the predicate it mirrors.
+const PORTLESS = [0, 1, 2, 3, 4, 2054, 23005]
+
 const form = (over: Partial<RigFormFacts> = {}): RigFormFacts => ({
   serialPort: '/dev/cu.usbserial-A',
   rigConn: 'serial',
   pttMethod: 'cat',
   rigModel: 1049,
-  radios: [{ id: 0, name: 'FT-710', serialPort: '/dev/cu.usbserial-A' }],
-  activeRadio: 0,
   ...over,
 })
 
 describe('checkRigForm', () => {
   it('passes a correct setup silently', () => {
-    expect(checkRigForm(form(), PORTS, 0)).toEqual([])
+    expect(checkRigForm(form(), PORTS, PORTLESS)).toEqual([])
   })
 
   it('ignores a network rig entirely — it has no serial port to be wrong about', () => {
-    const checks = checkRigForm(form({ rigConn: 'network', serialPort: '' }), PORTS, 0)
+    const checks = checkRigForm(form({ rigConn: 'network', serialPort: '' }), PORTS, PORTLESS)
     expect(checks).toEqual([])
   })
 
   it('blocks a rig model with no port — CAT cannot work without one', () => {
-    const checks = checkRigForm(form({ serialPort: '' }), PORTS, 0)
+    const checks = checkRigForm(form({ serialPort: '' }), PORTS, PORTLESS)
     expect(blocks(checks)).toBe(true)
     expect(checks[0].message).toMatch(/no serial port/i)
   })
@@ -36,47 +38,79 @@ describe('checkRigForm', () => {
     const checks = checkRigForm(
       form({ serialPort: '', rigModel: 0, pttMethod: 'vox' }),
       PORTS,
-      0,
+      PORTLESS,
     )
     expect(checks).toEqual([])
   })
 
+  // THE GATE. A whole class of models is served over TCP or a virtual COM pair by a program on
+  // this machine, and is configured with NO port on purpose. Ungated, the check above called
+  // every one of them an error and refused the save.
+  it.each([
+    [4, 'FLRig'],
+    [2054, 'Thetis'],
+    [23005, 'SmartSDR'],
+  ])('allows model %i (%s) with no port — it is served by software, not a cable', (model) => {
+    const checks = checkRigForm(
+      form({ serialPort: '', rigModel: model, pttMethod: 'rts' }),
+      PORTS,
+      PORTLESS,
+    )
+    expect(checks).toEqual([])
+  })
+
+  // Positive control for the gate: the same call with a REAL rig must still block, or the two
+  // cases above would pass for the wrong reason (a check that stopped firing at all).
+  it('still blocks a real rig with no port, so the gate is a gate and not an off switch', () => {
+    const checks = checkRigForm(form({ serialPort: '', rigModel: 1049 }), PORTS, PORTLESS)
+    expect(blocks(checks)).toBe(true)
+  })
+
+  it('does not block when the portless rule could not be read', () => {
+    // Empty list = the backend could not answer. Blocking then would make an unreadable rule the
+    // reason an operator cannot save a configuration that is fine.
+    const checks = checkRigForm(form({ serialPort: '', rigModel: 1049 }), PORTS, [])
+    expect(blocks(checks)).toBe(false)
+  })
+
+  it('survives a non-array where the rule should be, rather than throwing mid-save', () => {
+    // This runs inside the save handler. A throw here aborts the save with no message — which is
+    // the silent no-op this whole file exists to prevent. It happened: under the panel's test
+    // mocks the fetch resolved `null`, and three unrelated save tests died on `.includes`.
+    const checks = checkRigForm(
+      form({ serialPort: '', rigModel: 1049 }),
+      PORTS,
+      null as unknown as number[],
+    )
+    expect(blocks(checks)).toBe(false)
+  })
+
   it('blocks a /dev/tty.* port, which hangs on carrier instead of failing', () => {
-    const checks = checkRigForm(form({ serialPort: '/dev/tty.usbserial-A' }), PORTS, 0)
+    const checks = checkRigForm(form({ serialPort: '/dev/tty.usbserial-A' }), PORTS, PORTLESS)
     expect(blocks(checks)).toBe(true)
     expect(checks.some((c) => /dial-in device/.test(c.message))).toBe(true)
   })
 
-  it('blocks two radios sharing one CAT port', () => {
-    const checks = checkRigForm(
-      form({
-        radios: [
-          { id: 0, name: 'FT-710', serialPort: '/dev/cu.usbserial-A' },
-          { id: 1, name: 'FTX-1', serialPort: '/dev/cu.usbserial-A' },
-        ],
-      }),
-      PORTS,
-      1, // editing the FTX-1: the clash is with the OTHER radio
-    )
-    expect(blocks(checks)).toBe(true)
-    expect(checks.some((c) => /FT-710 already uses/.test(c.message))).toBe(true)
-  })
-
-  it('does not accuse a radio of clashing with itself', () => {
-    // The radio being edited already holds this port — that is the normal case, not a clash.
-    expect(checkRigForm(form(), PORTS, 0)).toEqual([])
-  })
-
   it('blocks PTT over CAT with no rig model — nothing to send the keying command to', () => {
-    const checks = checkRigForm(form({ rigModel: 0, pttMethod: 'cat' }), PORTS, 0)
+    const checks = checkRigForm(form({ rigModel: 0, pttMethod: 'cat' }), PORTS, PORTLESS)
     expect(blocks(checks)).toBe(true)
     expect(checks.some((c) => /PTT is set to CAT/.test(c.message))).toBe(true)
   })
 
   it('warns, but does NOT block, when the port is simply not plugged in right now', () => {
-    const checks = checkRigForm(form({ serialPort: 'COM9' }), PORTS, 0)
+    const checks = checkRigForm(form({ serialPort: 'COM9' }), PORTS, PORTLESS)
     expect(blocks(checks)).toBe(false)
     expect(checks[0].level).toBe('warning')
     expect(checks[0].message).toMatch(/not connected right now/)
+  })
+
+  // Port collisions belong to the backend (`settings::serial_port_conflicts`), which App.tsx
+  // already surfaces as `radioConfigWarning`. This file must not grow a second, unqualified
+  // opinion on them: the earlier version here ignored `enabled`, `rig_model` and `rig_conn`,
+  // compared case-sensitively, and BLOCKED — so it refused to save a station that shares one
+  // cable between two rigs on purpose.
+  it('says nothing about two radios sharing a port — that rule lives in the backend', () => {
+    const checks = checkRigForm(form({ serialPort: 'COM5' }), PORTS, PORTLESS)
+    expect(checks.some((c) => /already uses|cannot share/i.test(c.message))).toBe(false)
   })
 })

--- a/ui/src/rigFormChecks.ts
+++ b/ui/src/rigFormChecks.ts
@@ -6,12 +6,22 @@
  * and looks dead. Each check below is a mistake that is easy to make, invisible at save time, and
  * expensive to diagnose afterwards, because the symptom appears far from the cause.
  *
- * Pure on purpose. Everything is decided from the form plus the enumerated ports, so it is
+ * Pure on purpose. Everything is decided from the form plus facts passed in, so it is
  * unit-testable without hardware, a running app, or a rig.
  *
  * An `error` stops the save; a `warning` is stated and the operator proceeds. The split matters:
  * an operator with an unusual-but-correct setup must never be locked out of their own
  * configuration by a heuristic, so only things that CANNOT be right block.
+ *
+ * WHAT IS DELIBERATELY NOT HERE — two ports collide (two profiles on one serial port). The
+ * backend already decides that, in `settings::serial_port_conflicts`, and App.tsx already puts
+ * its verdict in the status lane as `radioConfigWarning`. That rule carries four qualifiers a
+ * form-side copy loses on sight — the other profile must be `enabled`, have `rig_model > 0`, be
+ * on `rig_conn == "serial"` and have a non-empty port, and the comparison is case-insensitive —
+ * so the copy fires on disabled profiles and misses `COM3` vs `com3`. It is also a WARNING
+ * there, correctly: a station that swaps one cable between two rigs has both profiles on one
+ * port on purpose and must still be able to save. One rule, one place; this file does not get a
+ * second opinion on it.
  */
 export type RigCheck = { level: 'error' | 'warning'; message: string }
 
@@ -21,21 +31,19 @@ export interface RigFormFacts {
   rigConn: string
   pttMethod: string
   rigModel: number
-  radios?: { id: number; name: string; serialPort: string }[]
-  /** Optional on `Settings` (a pre-roster config has none); treated as radio 0. */
-  activeRadio?: number
-}
-
-/** Which radio the form is describing — the one being edited, else the active one. */
-function targetRadioId(form: RigFormFacts, editingRadioId: number | null | undefined): number {
-  return editingRadioId ?? form.activeRadio ?? 0
 }
 
 export function checkRigForm(
   form: RigFormFacts,
   /** Names of the ports currently enumerated. Presence is all these checks need. */
   ports: string[],
-  editingRadioId: number | null | undefined,
+  /**
+   * Models that need no serial port, from `getPortlessRigModels()` — the backend's own
+   * `model <= 4 || is_software_cat_profile(model)` (crates/tempo-audio/src/usbrig.rs:266).
+   * Empty means the rule could not be read, and then the port check does not BLOCK: an
+   * unreadable rule must not be why a correct configuration cannot be saved.
+   */
+  portlessModels: number[],
 ): RigCheck[] {
   const out: RigCheck[] = []
   // A network rig has no serial port at all; none of this applies.
@@ -43,9 +51,19 @@ export function checkRigForm(
 
   const port = form.serialPort.trim()
   if (!port) {
-    // A model is set, so CAT is wanted — and CAT with no port is the one case where "nothing
-    // configured" and "misconfigured" look identical afterwards.
-    if (form.rigModel !== 0) {
+    // CAT is wanted and there is nowhere to send it — the one case where "nothing configured"
+    // and "misconfigured" look identical afterwards.
+    //
+    // Gated on the portless set, because a whole class of models is served over TCP or a
+    // virtual COM pair by a program on this machine: Dummy, NET rigctl, FLRig, Thetis,
+    // PowerSDR, SmartSDR, SDR Console. Those are configured with no port ON PURPOSE, and
+    // before this gate the check called every one of them an error and blocked the save.
+    // Model 0 (None/VOX) is in that set too, so "no model chosen" needs no separate case.
+    // `Array.isArray` rather than a bare `.length`: this runs inside the save handler, and a
+    // throw here would abort the save with no message at all — the exact failure mode the rest
+    // of this file exists to prevent.
+    const ruleKnown = Array.isArray(portlessModels) && portlessModels.length > 0
+    if (ruleKnown && !portlessModels.includes(form.rigModel)) {
       out.push({
         level: 'error',
         message: 'No serial port chosen — a rig model is set, so CAT needs a port.',
@@ -72,17 +90,6 @@ export function checkRigForm(
     out.push({
       level: 'error',
       message: `${port} is a dial-in device and will hang waiting for carrier. Use the matching /dev/cu.… port instead.`,
-    })
-  }
-
-  // Another radio already uses it. Two profiles on one port means two daemons fighting for it; the
-  // loser dies and its radio silently stops responding.
-  const me = targetRadioId(form, editingRadioId)
-  const clash = (form.radios ?? []).find((r) => r.id !== me && r.serialPort.trim() === port)
-  if (clash) {
-    out.push({
-      level: 'error',
-      message: `${clash.name} already uses ${port}. Two radios cannot share one CAT port.`,
     })
   }
 

--- a/ui/src/rigFormChecks.ts
+++ b/ui/src/rigFormChecks.ts
@@ -1,0 +1,105 @@
+/**
+ * Pre-save checks for the rig form.
+ *
+ * The form has exactly one check — the callsign — so every way of getting the RADIO wrong saves
+ * silently and then behaves like broken hardware: no CAT, no keying, or a rig that answers nothing
+ * and looks dead. Each check below is a mistake that is easy to make, invisible at save time, and
+ * expensive to diagnose afterwards, because the symptom appears far from the cause.
+ *
+ * Pure on purpose. Everything is decided from the form plus the enumerated ports, so it is
+ * unit-testable without hardware, a running app, or a rig.
+ *
+ * An `error` stops the save; a `warning` is stated and the operator proceeds. The split matters:
+ * an operator with an unusual-but-correct setup must never be locked out of their own
+ * configuration by a heuristic, so only things that CANNOT be right block.
+ */
+export type RigCheck = { level: 'error' | 'warning'; message: string }
+
+/** The subset of the settings form these checks read. */
+export interface RigFormFacts {
+  serialPort: string
+  rigConn: string
+  pttMethod: string
+  rigModel: number
+  radios?: { id: number; name: string; serialPort: string }[]
+  /** Optional on `Settings` (a pre-roster config has none); treated as radio 0. */
+  activeRadio?: number
+}
+
+/** Which radio the form is describing — the one being edited, else the active one. */
+function targetRadioId(form: RigFormFacts, editingRadioId: number | null | undefined): number {
+  return editingRadioId ?? form.activeRadio ?? 0
+}
+
+export function checkRigForm(
+  form: RigFormFacts,
+  /** Names of the ports currently enumerated. Presence is all these checks need. */
+  ports: string[],
+  editingRadioId: number | null | undefined,
+): RigCheck[] {
+  const out: RigCheck[] = []
+  // A network rig has no serial port at all; none of this applies.
+  if (form.rigConn === 'network') return out
+
+  const port = form.serialPort.trim()
+  if (!port) {
+    // A model is set, so CAT is wanted — and CAT with no port is the one case where "nothing
+    // configured" and "misconfigured" look identical afterwards.
+    if (form.rigModel !== 0) {
+      out.push({
+        level: 'error',
+        message: 'No serial port chosen — a rig model is set, so CAT needs a port.',
+      })
+    }
+    return out
+  }
+
+  const present = ports.includes(port)
+
+  // Present at all. A saved port can legitimately be absent (rig switched off), so this is a
+  // warning — but the operator should know now rather than wonder later why CAT never connects.
+  if (!present) {
+    out.push({
+      level: 'warning',
+      message: `${port} is not connected right now — check the rig is powered on, or pick another port.`,
+    })
+  }
+
+  // Callout vs dial-in. `/dev/tty.*` blocks on carrier detect and simply hangs; `/dev/cu.*` is the
+  // one to open. They are offered as a pair, differ by four characters, and look interchangeable —
+  // and the failure is a hang, not an error, so nothing ever says which one was wrong.
+  if (port.startsWith('/dev/tty.')) {
+    out.push({
+      level: 'error',
+      message: `${port} is a dial-in device and will hang waiting for carrier. Use the matching /dev/cu.… port instead.`,
+    })
+  }
+
+  // Another radio already uses it. Two profiles on one port means two daemons fighting for it; the
+  // loser dies and its radio silently stops responding.
+  const me = targetRadioId(form, editingRadioId)
+  const clash = (form.radios ?? []).find((r) => r.id !== me && r.serialPort.trim() === port)
+  if (clash) {
+    out.push({
+      level: 'error',
+      message: `${clash.name} already uses ${port}. Two radios cannot share one CAT port.`,
+    })
+  }
+
+  // CAT keying with no rig model. `pttMethod: 'cat'` and model 0 (None/VOX) cannot both be true —
+  // there is nothing to send the keying command to, so the rig never keys and nothing reports why.
+  if (form.pttMethod === 'cat' && form.rigModel === 0) {
+    out.push({
+      level: 'error',
+      message:
+        'PTT is set to CAT but the rig model is None/VOX — pick your rig model, or choose a different PTT method.',
+    })
+  }
+
+  return out
+}
+
+/** Convenience: does anything here stop a save? */
+export function blocks(checks: RigCheck[]): boolean {
+  return checks.some((c) => c.level === 'error')
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -9852,6 +9852,14 @@ select.settings-input {
   font-size: 13px;
   font-weight: 600;
 }
+/* A pre-save check that did NOT block the save. Distinct from .settings-error in colour, because
+   the difference that matters to the operator is "this stopped you" versus "this is worth
+   knowing" — and both can be on screen at once. */
+.settings-warn {
+  color: var(--alert-warning);
+  font-size: 13px;
+  font-weight: 600;
+}
 .settings-ok {
   color: var(--state-good);
   font-size: 13px;


### PR DESCRIPTION
## Summary

Following your note on #76 — *"save-time validation naming the missing field is the better fix and
would have caught your case regardless of colour"*. This is that.

The callsign is currently the only validated field, so every way of getting the **radio** wrong
saves silently and then presents as broken hardware. The symptom always appears far from the cause,
which is what makes these expensive to diagnose.

**Four things that cannot be right now block the save and name the fix:**

- **a rig model with no serial port** — CAT is wanted and cannot work;
- **a `/dev/tty.*` port**, which blocks on carrier detect and *hangs* rather than failing. It sits
  next to the `/dev/cu.*` twin in the picker, differs by four characters, and nothing ever says
  which one was wrong;
- **two radios on one CAT port** — two daemons fight for it, the loser dies, and that radio
  silently stops responding;
- **PTT over CAT with model 0 (None/VOX)** — there is nothing to send the keying command to, so the
  rig simply never keys.

**One thing that might be right only warns:** a port that isn't enumerated right now. A saved port
is legitimately absent when the rig is switched off, so it must not block — but the operator should
know now rather than wonder later.

**The split is the design.** An operator with an unusual-but-correct station must never be locked
out of their own configuration by a heuristic, so only impossibilities block. Warnings are stated
beside the save button and left visible; the save proceeds.

`checkRigForm` is pure — the form plus the enumerated port names — so it is unit-testable without
hardware, a rig, or a running app.

## Linked issue

Refs #76, refs #6

## Validation

- **Validated against:** Bench — nine unit tests covering each check, both directions (including
  that a radio is never accused of clashing with itself, and that no port + no model is VOX rather
  than a mistake); plus the full UI suite.
- **Notes:** **3202 passed / 0 failed across 256 files**, `tsc -b` clean. Every case is one I hit
  during setup on a two-radio station — the `tty.*` hang and the shared-port clash in particular.
  No on-air validation applies; this is a pre-save form check.

I deliberately left out two further checks I have locally, because both depend on USB topology
(which interface of a dual bridge carries CAT, and whether the chosen sound card is inside the radio
on that CAT port). That needs `SerialPortInfo` to carry more than `{name, label}`, and it is
macOS-only work you have not seen — so it is a separate conversation rather than something smuggled
in here.

## Checklist

- [x] `cargo test` passes on the workspace — no Rust change in this PR.
- [x] `cargo clippy --all-targets` is clean — no Rust change in this PR.
- [x] UI touched? Yes — `tsc -b` passes and the UI suite is green.
- [x] Docs updated where relevant — the reasoning is in the module header and commit message.
- [x] **Validation honesty:** I have stated above what this change was validated against.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
