### PR TITLE
Destructive actions ask through an in-app dialog; window.confirm is inert on macOS

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -147,6 +147,7 @@ import { Logbook } from './components/Logbook'
 import { RoamPanel } from './components/RoamPanel'
 import { SettingsPanel } from './components/SettingsPanel'
 import { Toasts } from './components/Toasts'
+import { ConfirmHost, confirmDialog } from './confirm'
 import { OnboardingBanner } from './components/OnboardingBanner'
 import { PounceBanner } from './components/PounceBanner'
 import { UpdateBanner } from './components/UpdateBanner'
@@ -996,11 +997,14 @@ export default function App() {
   // the same guard. Unconditional is right: the recents list only renders threads that
   // have messages, so there is no empty-thread case to skip. The copy names the
   // non-obvious consequence — deleting also cancels still-queued outbound traffic.
-  const handleArchive = useCallback((peer: string) => {
+  const handleArchive = useCallback(async (peer: string) => {
     if (
-      !window.confirm(
-        `Delete the conversation with ${peer}? Any messages still waiting to send will be cancelled. This can't be undone.`,
-      )
+      !(await confirmDialog({
+        title: `Delete the conversation with ${peer}?`,
+        body: "Any messages still waiting to send will be cancelled. This can't be undone.",
+        confirmLabel: 'Delete conversation',
+        danger: true,
+      }))
     )
       return
     void withErrorToast(
@@ -2786,6 +2790,9 @@ export default function App() {
       </div>
 
       <Toasts />
+      {/* Destructive actions confirm through this, not window.confirm — which is inert in the
+          macOS webview and silently answered "no" to every one of them. See src/confirm.tsx. */}
+      <ConfirmHost />
       <Announcer />
 
       {radioPicker?.showPicker && (

--- a/ui/src/DetachedPanel.test.tsx
+++ b/ui/src/DetachedPanel.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react'
 import { DetachedPanel } from './DetachedPanel'
+import { confirmDialog } from './confirm'
 import { selectPeer, workSpot, setFrequency, getNeedAlerts } from './api'
 import { readEnabledModes } from './useFeatures'
 import type { NeedAlert } from './types'
@@ -130,6 +131,43 @@ describe('DetachedPanel selection forwarding', () => {
     render(<DetachedPanel panel="connect" />)
     fireEvent.click(screen.getByTestId('deselect'))
     expect(mockedSelectPeer).toHaveBeenCalledWith(null)
+  })
+})
+
+describe('DetachedPanel destructive confirmations', () => {
+  // A torn-off window is a SEPARATE JS REALM, not another branch of the main window's tree.
+  // `confirmDialog` resolves through a module-level host, and `<ConfirmHost/>` mounted only in
+  // App — so in this document the global was null, the call logged and answered "no", and the
+  // ✕ on a conversation did nothing at all. Same symptom as the window.confirm bug this PR
+  // fixes, one layer up.
+  // Every branch, not just the two that mount <Toasts/>: the body returns from nine places and
+  // a host present in one tree but absent in another is the same silent failure, moved. The
+  // host is mounted once around the whole panel, so this holds for branches added later too.
+  // A representative spread rather than all nine: a branch that mounts <Toasts/> (waterfall),
+  // two that do not (connect, needed), and the unknown-panel fallback. 'sats' and 'operate' are
+  // left out because they need api exports this file's hand-written mock does not carry — the
+  // host is mounted around the body, so no branch can differ anyway.
+  it.each(['connect', 'waterfall', 'needed', 'nonexistent-panel'])(
+    'the %s pop-out can ask a destructive question and get a real answer',
+    async (panel) => {
+      render(<DetachedPanel panel={panel} />)
+      const answer = confirmDialog({ title: 'Delete the conversation with DL1ABC?' })
+      await waitFor(() =>
+        expect(screen.getByText('Delete the conversation with DL1ABC?')).toBeTruthy(),
+      )
+      screen.getByRole('button', { name: 'Confirm' }).click()
+      await expect(answer).resolves.toBe(true)
+    },
+  )
+
+  it('answers NO when dismissed, so a destructive action never proceeds unasked', async () => {
+    render(<DetachedPanel panel="connect" />)
+    const answer = confirmDialog({ title: 'Delete the conversation with DL1ABC?' })
+    await waitFor(() =>
+      expect(screen.getByText('Delete the conversation with DL1ABC?')).toBeTruthy(),
+    )
+    screen.getByRole('button', { name: 'Cancel' }).click()
+    await expect(answer).resolves.toBe(false)
   })
 })
 

--- a/ui/src/DetachedPanel.tsx
+++ b/ui/src/DetachedPanel.tsx
@@ -7,7 +7,7 @@
 // self-fetches its spectrum), and its action callbacks drive the same engine, so state
 // stays consistent across every window.
 import { useEffect, useMemo, useState } from 'react'
-import { confirmDialog } from './confirm'
+import { confirmDialog, ConfirmHost } from './confirm'
 import type {
   AppSnapshot,
   BandChannel,
@@ -91,7 +91,27 @@ function loadOperateLayout(): OperateLayout {
   return surfaceGet('nexus.operate.layout') === 'classic' ? 'classic' : 'roster'
 }
 
+/** A torn-off window is a SEPARATE JS REALM, not another branch of the main window's tree, so
+ *  it needs its own confirm host: `confirmDialog` resolves through a module-level global, and in
+ *  this document that global is `null` until something mounts one here. Without it the guarded
+ *  action fails closed — it logs and answers "no" — which is how the ✕ on a conversation in this
+ *  panel did nothing at all.
+ *
+ *  Mounted ONCE around the whole panel rather than beside each `<Toasts/>`, because the body
+ *  below returns from nine separate branches and only two of them mount toasts. Per-branch would
+ *  reproduce the very bug this fixes: a host present in one tree and absent in another, failing
+ *  silently in whichever branch someone forgets. The dialog portals (`RD.Portal`), so where this
+ *  sits in the tree has no bearing on layout — only on whether it exists at all. */
 export function DetachedPanel({ panel }: { panel: string }) {
+  return (
+    <>
+      <DetachedPanelBody panel={panel} />
+      <ConfirmHost />
+    </>
+  )
+}
+
+function DetachedPanelBody({ panel }: { panel: string }) {
   const [theme] = useTheme()
   // Pop-outs follow field mode: a separate document re-applies the attribute itself, the
   // same way it mirrors the theme — outdoors is a fact about the station, not a window.

--- a/ui/src/DetachedPanel.tsx
+++ b/ui/src/DetachedPanel.tsx
@@ -7,6 +7,7 @@
 // self-fetches its spectrum), and its action callbacks drive the same engine, so state
 // stays consistent across every window.
 import { useEffect, useMemo, useState } from 'react'
+import { confirmDialog } from './confirm'
 import type {
   AppSnapshot,
   BandChannel,
@@ -209,11 +210,14 @@ export function DetachedPanel({ panel }: { panel: string }) {
   }
   // Mirrors App.tsx's handleArchive — the detached window had a silent no-op here, so the
   // ✕ did nothing at all in this panel.
-  const onArchive = (peer: string) => {
+  const onArchive = async (peer: string) => {
     if (
-      !window.confirm(
-        `Delete the conversation with ${peer}? Any messages still waiting to send will be cancelled. This can't be undone.`,
-      )
+      !(await confirmDialog({
+        title: `Delete the conversation with ${peer}?`,
+        body: "Any messages still waiting to send will be cancelled. This can't be undone.",
+        confirmLabel: 'Delete conversation',
+        danger: true,
+      }))
     )
       return
     apply(archiveConversation(peer))

--- a/ui/src/components/Logbook.tsx
+++ b/ui/src/components/Logbook.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { confirmDialog } from '../confirm'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { LoggedQso } from '../types'
 import { gpuCapableForGlobe } from '../gpu'
@@ -457,7 +458,15 @@ export function Logbook({
   }
 
   const onDelete = async (q: LoggedQso, i: number) => {
-    if (!window.confirm(`Delete the QSO with ${q.call} on ${q.band}? This can't be undone.`)) return
+    if (
+      !(await confirmDialog({
+        title: `Delete the QSO with ${q.call} on ${q.band}?`,
+        body: "This removes it from your log. This can't be undone.",
+        confirmLabel: 'Delete QSO',
+        danger: true,
+      }))
+    )
+      return
     const snap = await withErrorToast(() => deleteQso(i), 'Could not delete the QSO')
     if (snap) {
       pushToast(`Deleted ${q.call}`, 'success')

--- a/ui/src/components/RadioProgView.tsx
+++ b/ui/src/components/RadioProgView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { confirmDialog } from '../confirm'
 import type {
   GeoCandidate,
   ProgChannel,
@@ -271,12 +272,19 @@ export function RadioProgView({ myGrid, catOk = false }: Props) {
     }
     setRows((rs) => [...rs, { channel: { ...row.channel }, nameEdited: false }])
   }
-  const addAllShown = () => {
+  const addAllShown = async () => {
     const candidates = shown.filter(
       (row) => isProgrammable(row.record) && !inList.has(row.channel.id),
     )
     if (candidates.length === 0) return
-    if (candidates.length > 50 && !window.confirm(`Add ${candidates.length} channels?`)) return
+    if (
+      candidates.length > 50 &&
+      !(await confirmDialog({
+        title: `Add ${candidates.length} channels?`,
+        confirmLabel: 'Add channels',
+      }))
+    )
+      return
     setRows((rs) => [
       ...rs,
       ...candidates.slice(0, 200).map((row) => ({ channel: { ...row.channel }, nameEdited: false })),
@@ -939,7 +947,16 @@ export function RadioProgView({ myGrid, catOk = false }: Props) {
               className="settings-refresh rp-clear"
               disabled={rows.length === 0}
               onClick={() => {
-                if (window.confirm('Clear the whole channel list?')) setRows([])
+                void (async () => {
+                  if (
+                    await confirmDialog({
+                      title: 'Clear the whole channel list?',
+                      confirmLabel: 'Clear list',
+                      danger: true,
+                    })
+                  )
+                    setRows([])
+                })()
               }}
             >
               Clear

--- a/ui/src/components/SettingsPanel.removeradio.test.tsx
+++ b/ui/src/components/SettingsPanel.removeradio.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+//
+// Remove radio, end to end through the confirmation — the path that reported this bug.
+//
+// `window.confirm` is INERT in the Tauri webview (wry implements no `runJavaScriptConfirmPanel`,
+// so WKWebView shows nothing and returns false), which made `if (!window.confirm(…)) return`
+// cancel every destructive action silently. Remove radio was the operator's report: the button
+// did nothing, with no dialog and no error.
+//
+// `confirm.test.tsx` pins the dialog primitive. This pins the WIRING — that the panel's Remove
+// button reaches a real dialog, and that the answer decides whether the radio is actually
+// removed. Neither half was covered before: no test touched any of the twelve converted paths.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { SettingsPanel } from './SettingsPanel'
+import { ConfirmHost } from '../confirm'
+import type { FeaturesApi } from '../useFeatures'
+import defaultSettings from './__fixtures__/defaultSettings.json'
+
+const api = vi.hoisted(() => {
+  const spies: Record<string, ReturnType<typeof vi.fn>> = {}
+  const get = (name: string) => {
+    if (!spies[name]) spies[name] = vi.fn(() => Promise.resolve(null))
+    return spies[name]
+  }
+  return { spies, get }
+})
+
+// Mock every export of `../api`, derived from the real module — a hand-kept list goes stale and
+// makes the panel throw on mount, which reads as a regression rather than the mock it is.
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const mod: Record<string, unknown> = {}
+  for (const name of Object.keys(actual)) {
+    mod[name] = typeof actual[name] === 'function' ? api.get(name) : actual[name]
+  }
+  return mod
+})
+vi.mock('../toast', () => ({
+  pushToast: vi.fn(),
+  withErrorToast: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}))
+
+const FTDX10 = {
+  id: 0,
+  name: 'FTDX10',
+  enabled: true,
+  serialPort: 'COM3',
+  baud: 38400,
+  rigModel: 1042,
+  rigModelName: 'Yaesu FTDX10',
+  rigConn: 'serial',
+  rigAddr: '',
+  rigctldPort: 4532,
+  rotctldPort: 4533,
+  icomNativeCat: false,
+  audioIn: 'in-0',
+  audioOut: 'out-0',
+  txLevel: 1,
+  rxGain: 1,
+  pttMethod: 'cat',
+  rotatorModel: 0,
+  rotatorPort: '',
+  rotatorBaud: 9600,
+  rotatorHost: '',
+  nativeScope: 'auto',
+  bands: [],
+}
+// The radio the operator removes. It must NOT be the active one: Remove is only offered for a
+// non-active radio in a multi-radio roster, which is exactly the case that was reported broken.
+const IC9700 = {
+  ...FTDX10,
+  id: 1,
+  name: 'IC-9700',
+  serialPort: 'COM7',
+  rigModel: 3081,
+  rigModelName: 'Icom IC-9700',
+  rigctldPort: 4534,
+}
+
+function twoRadioSettings() {
+  return {
+    ...defaultSettings,
+    ...FTDX10,
+    mycall: 'KD9TAW',
+    mygrid: 'EN52',
+    activeRadio: 0,
+    radios: [FTDX10, IC9700],
+  } as never
+}
+
+const features: FeaturesApi = {
+  enabled: () => true,
+  setEnabled: vi.fn(),
+  all: () => [],
+  profile: 'full',
+  setProfile: vi.fn(),
+} as unknown as FeaturesApi
+
+/** The panel WITH a confirm host, which is how App renders it. Without a host `confirmDialog`
+ *  fails closed, so a hostless render would "pass" a dismissal test for the wrong reason. */
+function renderPanel() {
+  return render(
+    <>
+      <SettingsPanel
+        activeRadioId={0}
+        scale={1 as never}
+        scaleMode={'auto' as never}
+        scaleCap={1 as never}
+        onScaleModeChange={() => {}}
+        onScaleCapChange={() => {}}
+        density={'comfortable' as never}
+        onDensityChange={() => {}}
+        onResetLayout={() => {}}
+        features={features}
+      />
+      <ConfirmHost />
+    </>,
+  )
+}
+
+async function clickRemove() {
+  renderPanel()
+  fireEvent.click(await screen.findByRole('tab', { name: 'Radio' }))
+  const remove = await screen.findByRole('button', { name: 'Remove' })
+  fireEvent.click(remove)
+}
+
+beforeEach(() => {
+  for (const spy of Object.values(api.spies)) {
+    spy.mockClear()
+    spy.mockImplementation(() => Promise.resolve(null))
+  }
+  api.get('getRigModels').mockImplementation(() => Promise.resolve([]))
+  api.get('getAllRigModels').mockImplementation(() => Promise.resolve([]))
+  api.get('getSerialPortsDetailed').mockImplementation(() => Promise.resolve([]))
+  api.get('getBandPlan').mockImplementation(() => Promise.resolve([]))
+  api.get('getAudioDevices').mockImplementation(() => Promise.resolve({ input: [], output: [] }))
+  api.get('getCredentialsStatus').mockImplementation(() => Promise.resolve({}))
+  api.get('detectRigs').mockImplementation(() => Promise.resolve([]))
+  api.get('appVersion').mockImplementation(() => Promise.resolve('0.17.12'))
+  api.get('getSettings').mockImplementation(() => Promise.resolve(twoRadioSettings()))
+})
+afterEach(cleanup)
+
+describe('Remove radio asks first, and the answer decides', () => {
+  it('shows a real dialog naming the radio — not window.confirm, which shows nothing', async () => {
+    await clickRemove()
+    await waitFor(() => expect(screen.getByText('Remove IC-9700?')).toBeTruthy())
+    // The operator is told what goes and what does not, before answering.
+    expect(document.body.textContent).toContain('Your contact log is not affected')
+    // And nothing has happened yet.
+    expect(api.get('removeRadio')).not.toHaveBeenCalled()
+  })
+
+  it('removes the radio when the operator confirms', async () => {
+    await clickRemove()
+    await waitFor(() => expect(screen.getByText('Remove IC-9700?')).toBeTruthy())
+    screen.getByRole('button', { name: 'Remove radio' }).click()
+
+    // The whole point of the fix: the click reaches the backend, for the RIGHT radio.
+    await waitFor(() => expect(api.get('removeRadio')).toHaveBeenCalledWith(1))
+  })
+
+  it('keeps the radio when the operator dismisses', async () => {
+    await clickRemove()
+    await waitFor(() => expect(screen.getByText('Remove IC-9700?')).toBeTruthy())
+    screen.getByRole('button', { name: 'Cancel' }).click()
+
+    await waitFor(() => expect(screen.queryByText('Remove IC-9700?')).toBeNull())
+    expect(api.get('removeRadio')).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { SAT_VFO_MAPS } from '../features/satVfo'
+import { confirmDialog } from '../confirm'
 import {
   confirmSatUplink,
   exportSettingsBundle,
@@ -535,11 +536,14 @@ export function SettingsPanel({
     // Destructive and not undoable, so it asks — and names what goes, because "restore" sounds
     // additive and is not.
     if (
-      !window.confirm(
-        `Replace your current setup with ${f.name}?\n\nYour radios, preferences, memory ` +
-          `channels, watchlist and chase sets will be replaced. Your contact log is not ` +
-          `affected. This cannot be undone.`,
-      )
+      !(await confirmDialog({
+        title: `Replace your current setup with ${f.name}?`,
+        body:
+          'Your radios, preferences, memory channels, watchlist and chase sets will be replaced. ' +
+          'Your contact log is not affected. This cannot be undone.',
+        confirmLabel: 'Restore',
+        danger: true,
+      }))
     ) {
       return
     }
@@ -1187,10 +1191,15 @@ export function SettingsPanel({
     )
   }
 
-  const resetOverrides = () => {
+  const resetOverrides = async () => {
     if (
       (form?.workingFrequencies?.length ?? 0) > 0 &&
-      !window.confirm('Clear all working-frequency overrides and go back to the stock WSJT-X table?')
+      !(await confirmDialog({
+        title: 'Clear all working-frequency overrides?',
+        body: 'The stock WSJT-X frequency table is restored.',
+        confirmLabel: 'Clear overrides',
+        danger: true,
+      }))
     ) {
       return
     }
@@ -1246,11 +1255,18 @@ export function SettingsPanel({
   const handleAddRadio = () => {
     void withErrorToast(() => addRadio(), 'Could not add a radio').then((s) => s && reloadRadios())
   }
-  const handleRemoveRadio = (id: number) => {
+  const handleRemoveRadio = async (id: number) => {
     // Destructive + immediate + unrecoverable (drops the radio's CAT/audio config, its unique
     // rigctld port, and band coverage) — confirm before removing.
     const r = form?.radios?.find((p) => p.id === id)
-    if (!window.confirm(`Remove ${r?.name ?? 'this radio'}? This deletes its CAT/audio config and can't be undone.`)) {
+    if (
+      !(await confirmDialog({
+        title: `Remove ${r?.name ?? 'this radio'}?`,
+        body: "This deletes its CAT/audio config, its rigctld port and its band coverage. Your contact log is not affected. This can't be undone.",
+        confirmLabel: 'Remove radio',
+        danger: true,
+      }))
+    ) {
       return
     }
     void withErrorToast(() => removeRadio(id), 'Could not remove the radio').then((s) => s && reloadRadios())
@@ -1321,9 +1337,17 @@ export function SettingsPanel({
   // EDIT a radio's config without touching what you're operating on: load that radio's profile
   // into the rig form LOCALLY (no backend call, no live rig swap, no dropped carrier). Save then
   // writes just this radio (via update_radio_profile) when it isn't the active one.
-  const handleConfigureRadio = (id: number) => {
+  const handleConfigureRadio = async (id: number) => {
     if (id === editingRadioId) return
-    if (dirtyRef.current && !window.confirm('Discard unsaved changes to the radio you were editing?')) {
+    if (
+      dirtyRef.current &&
+      !(await confirmDialog({
+        title: 'Discard unsaved changes to the radio you were editing?',
+        body: 'The edits you have not saved for that radio are lost.',
+        confirmLabel: 'Discard and switch',
+        danger: true,
+      }))
+    ) {
       return
     }
     const r = form?.radios?.find((p) => p.id === id)
@@ -1335,8 +1359,16 @@ export function SettingsPanel({
 
   // MAKE ACTIVE — the operating radio swap (carrier dropped first). Separate from Edit now, so
   // configuring a second rig no longer forces you to start operating on it.
-  const handleMakeActive = (id: number) => {
-    if (dirtyRef.current && !window.confirm('Discard unsaved changes and switch the operating radio?')) {
+  const handleMakeActive = async (id: number) => {
+    if (
+      dirtyRef.current &&
+      !(await confirmDialog({
+        title: 'Discard unsaved changes and switch the operating radio?',
+        body: 'The carrier is dropped before the swap. Unsaved edits to the radio you were editing are lost.',
+        confirmLabel: 'Discard and switch',
+        danger: true,
+      }))
+    ) {
       return
     }
     void withErrorToast(() => setActiveRadio(id), 'Could not switch radios').then((s) => {
@@ -2256,12 +2288,19 @@ export function SettingsPanel({
                     title={p.blurb}
                     onClick={() => {
                       // Switching from a hand-tuned set discards it — confirm first.
-                      if (
-                        features.profile !== 'custom' ||
-                        window.confirm(`Switch to “${p.label}”? This replaces your custom feature set.`)
-                      ) {
-                        features.applyProfile(p.id)
-                      }
+                      void (async () => {
+                        if (
+                          features.profile !== 'custom' ||
+                          (await confirmDialog({
+                            title: `Switch to “${p.label}”?`,
+                            body: 'This replaces your custom feature set.',
+                            confirmLabel: 'Switch',
+                            danger: true,
+                          }))
+                        ) {
+                          features.applyProfile(p.id)
+                        }
+                      })()
                     }}
                   >
                     {p.label}

--- a/ui/src/components/SstvView.tsx
+++ b/ui/src/components/SstvView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { confirmDialog } from '../confirm'
 import type { AppSnapshot, BandChannel, SstvGalleryEntry, SstvHealth, SstvState } from '../types'
 import { Waterfall } from './Waterfall'
 import { CockpitHeader } from './CockpitHeader'
@@ -713,7 +714,14 @@ export function SstvView({ snap, theme = 'default', onSnap, active = true, onSet
   // small and several look alike.
   const deleteImage = async (g: { path: string; mode: string; finishedUtc: string }) => {
     const what = `${g.mode} received ${fmtUtc(g.finishedUtc)}`
-    if (!window.confirm(`Delete the ${what}?\n\nThe image file is removed and cannot be recovered.`))
+    if (
+      !(await confirmDialog({
+        title: `Delete the ${what}?`,
+        body: 'The image file is removed and cannot be recovered.',
+        confirmLabel: 'Delete image',
+        danger: true,
+      }))
+    )
       return
     await withErrorToast(async () => {
       await sstvDeleteImage(g.path)

--- a/ui/src/confirm.test.tsx
+++ b/ui/src/confirm.test.tsx
@@ -36,6 +36,23 @@ describe('confirmDialog', () => {
     await expect(answer).resolves.toBe(true)
   })
 
+  it('answers a superseded question NO instead of leaving its await hanging forever', async () => {
+    render(<ConfirmHost />)
+    const first = confirmDialog({ title: 'Delete radio 1?' })
+    await waitFor(() => expect(screen.getByText('Delete radio 1?')).toBeTruthy())
+
+    // A second question arrives before the first is answered — the fire-and-forget call sites in
+    // RadioProgView do not await one another. The first used to be dropped unresolved, so its
+    // caller waited for the lifetime of the window.
+    const second = confirmDialog({ title: 'Delete radio 2?' })
+    await expect(first).resolves.toBe(false)
+
+    // And the survivor is genuinely still live, not collateral damage from settling the first.
+    await waitFor(() => expect(screen.getByText('Delete radio 2?')).toBeTruthy())
+    screen.getByRole('button', { name: 'Confirm' }).click()
+    await expect(second).resolves.toBe(true)
+  })
+
   it('resolves false on Cancel', async () => {
     render(<ConfirmHost />)
     const answer = confirmDialog({ title: 'Reset everything?' })

--- a/ui/src/confirm.test.tsx
+++ b/ui/src/confirm.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+//
+// The confirm dialog replaces window.confirm, which is INERT in the Tauri webview: WKWebView only
+// shows a JS confirm if the host implements runJavaScriptConfirmPanel, and wry does not. So
+// `confirm()` returned false with no dialog, and every `if (!window.confirm(…)) return` guard
+// silently cancelled — Remove radio, Restore, Reset and eleven others did nothing at all
+// (operator, 2026-08-14).
+//
+// What is pinned here is the property that matters most: with no host mounted it must resolve
+// FALSE. A missing dialog that answered "yes" would turn this bug into silent data loss, which is
+// strictly worse than the silence it replaces.
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { confirmDialog, ConfirmHost } from './confirm'
+
+afterEach(cleanup)
+
+describe('confirmDialog', () => {
+  it('resolves FALSE when no host is mounted — never proceeds unconfirmed', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await expect(confirmDialog({ title: 'Delete everything?' })).resolves.toBe(false)
+    expect(err).toHaveBeenCalled() // and says so, rather than failing mutely
+    err.mockRestore()
+  })
+
+  it('shows the question and resolves true only on the affirmative button', async () => {
+    render(<ConfirmHost />)
+    const answer = confirmDialog({
+      title: 'Remove FT-710?',
+      body: 'This deletes its CAT config.',
+      confirmLabel: 'Remove radio',
+    })
+    await waitFor(() => expect(screen.getByText('Remove FT-710?')).toBeTruthy())
+    expect(screen.getByText('This deletes its CAT config.')).toBeTruthy()
+    screen.getByRole('button', { name: 'Remove radio' }).click()
+    await expect(answer).resolves.toBe(true)
+  })
+
+  it('resolves false on Cancel', async () => {
+    render(<ConfirmHost />)
+    const answer = confirmDialog({ title: 'Reset everything?' })
+    await waitFor(() => expect(screen.getByText('Reset everything?')).toBeTruthy())
+    screen.getByRole('button', { name: 'Cancel' }).click()
+    await expect(answer).resolves.toBe(false)
+  })
+})

--- a/ui/src/confirm.tsx
+++ b/ui/src/confirm.tsx
@@ -1,0 +1,91 @@
+/** In-app confirmation for destructive actions.
+ *
+ * WHY THIS EXISTS. `window.confirm` is INERT in this webview. A JS confirm only appears if the
+ * host implements WKWebView's `runJavaScriptConfirmPanel`; wry does not, so `confirm()` returns
+ * `false` immediately and shows nothing. Every guard written as
+ *
+ *     if (!window.confirm('…')) return
+ *
+ * therefore returns instantly, and the action silently does nothing at all. Reported by the
+ * operator on 2026-08-14 for Remove radio, then confirmed on Reset: no dialog, no effect, no
+ * error. Fifteen destructive actions were built on it.
+ *
+ * The unit tests could never catch it: they mock `window.confirm` to return `true`, so the suite
+ * exercises a dialog that does not exist in the real app.
+ *
+ * FAIL CLOSED. If the host is not mounted, `confirmDialog` resolves FALSE — a destructive action
+ * must never proceed unconfirmed. The opposite default would turn a missing dialog into a silent
+ * deletion, which is the worse half of the same bug.
+ */
+import { useEffect, useState } from 'react'
+import { Dialog } from './components/ui/Dialog'
+
+export interface ConfirmOptions {
+  /** The question, as a title. Say what will happen, not "Are you sure?". */
+  title: string
+  /** What the operator needs to know before answering — scope, and what is NOT affected. */
+  body?: string
+  /** Label for the affirmative button. Name the ACT ("Remove radio"), never "OK". */
+  confirmLabel?: string
+  cancelLabel?: string
+  /** Style the affirmative button as destructive. */
+  danger?: boolean
+}
+
+interface Request extends ConfirmOptions {
+  resolve: (ok: boolean) => void
+}
+
+let present: ((r: Request) => void) | null = null
+
+/** Ask the operator to confirm. Resolves true only on an explicit yes. */
+export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
+  if (!present) {
+    // No host mounted. Refuse rather than proceed: see FAIL CLOSED above.
+    console.error('confirmDialog: no <ConfirmHost/> mounted — refusing the action')
+    return Promise.resolve(false)
+  }
+  return new Promise<boolean>((resolve) => present?.({ ...opts, resolve }))
+}
+
+/** Mount ONCE, near the app root. */
+export function ConfirmHost() {
+  const [req, setReq] = useState<Request | null>(null)
+
+  useEffect(() => {
+    present = setReq
+    return () => {
+      present = null
+    }
+  }, [])
+
+  const close = (ok: boolean) => {
+    req?.resolve(ok)
+    setReq(null)
+  }
+
+  return (
+    <Dialog
+      open={req !== null}
+      // ESC and overlay-click land here: anything that is not an explicit yes is a no.
+      onOpenChange={(open) => {
+        if (!open) close(false)
+      }}
+      title={req?.title ?? ''}
+      description={req?.body}
+    >
+      <div className="confirm-actions">
+        <button type="button" className="settings-refresh" onClick={() => close(false)} autoFocus>
+          {req?.cancelLabel ?? 'Cancel'}
+        </button>
+        <button
+          type="button"
+          className={req?.danger ? 'settings-save danger' : 'settings-save'}
+          onClick={() => close(true)}
+        >
+          {req?.confirmLabel ?? 'Confirm'}
+        </button>
+      </div>
+    </Dialog>
+  )
+}

--- a/ui/src/confirm.tsx
+++ b/ui/src/confirm.tsx
@@ -17,7 +17,7 @@
  * must never proceed unconfirmed. The opposite default would turn a missing dialog into a silent
  * deletion, which is the worse half of the same bug.
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Dialog } from './components/ui/Dialog'
 
 export interface ConfirmOptions {
@@ -51,16 +51,31 @@ export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
 /** Mount ONCE, near the app root. */
 export function ConfirmHost() {
   const [req, setReq] = useState<Request | null>(null)
+  // The same request the state holds, kept where a callback can settle it without reading
+  // through a render. Resolving inside a `setReq` updater would be a side effect in a function
+  // React is free to call twice (StrictMode), and `close` reading `req` would answer whichever
+  // request that closure captured rather than the one on screen.
+  const pending = useRef<Request | null>(null)
 
   useEffect(() => {
-    present = setReq
+    present = (next) => {
+      // A second question arriving while one is open REPLACES it, so the one being replaced must
+      // be answered on its way out or its `await` never settles and the caller waits for the
+      // lifetime of the window. Answered NO: the operator never saw it, and an unseen
+      // destructive question is a refusal. Reachable from the fire-and-forget call sites in
+      // RadioProgView, which do not await one another.
+      pending.current?.resolve(false)
+      pending.current = next
+      setReq(next)
+    }
     return () => {
       present = null
     }
   }, [])
 
   const close = (ok: boolean) => {
-    req?.resolve(ok)
+    pending.current?.resolve(ok)
+    pending.current = null
     setReq(null)
   }
 

--- a/ui/src/confirm.tsx
+++ b/ui/src/confirm.tsx
@@ -10,8 +10,17 @@
  * operator on 2026-08-14 for Remove radio, then confirmed on Reset: no dialog, no effect, no
  * error. Fifteen destructive actions were built on it.
  *
- * The unit tests could never catch it: they mock `window.confirm` to return `true`, so the suite
- * exercises a dialog that does not exist in the real app.
+ * WHY THE SUITE MISSED IT. Not, as first written here, because tests mocked `window.confirm` to
+ * return `true` — nothing in the suite mocks it at all. It is simpler and worse: none of the
+ * converted paths had ANY coverage. A guard nothing exercises cannot fail, whatever it returns.
+ * `confirm.test.tsx` pins this primitive; `SettingsPanel.removeradio.test.tsx` pins one whole
+ * path end to end, which is what would actually have caught it.
+ *
+ * TWO `window.confirm` CALLS REMAIN, deliberately (SetupHealth's Prove TX, SstvView's ISS
+ * 145.800 guard). Both are transmit-path, so converting them is a TX-behaviour change needing
+ * sign-off rather than part of a UI pass. Note what they do on macOS meanwhile: both read the
+ * inert `false` as "no", so each BLOCKS its action. Safe — nothing keys — but Prove TX is a dead
+ * button there, and SSTV cannot be sent on 145.800 at all.
  *
  * FAIL CLOSED. If the host is not mounted, `confirmDialog` resolves FALSE — a destructive action
  * must never proceed unconfirmed. The opposite default would turn a missing dialog into a silent

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -21694,3 +21694,12 @@ tr.sel .aprs-sym {
 :where(html[data-viewport='xs'], html[data-viewport='sm']) .gsg-hero-card {
   padding: var(--space-6) var(--space-5) 22px;
 }
+
+/* Confirmation dialog actions (src/confirm.tsx). Cancel first in the DOM so it takes focus and
+   ESC/overlay-click agree with it: for a destructive question the safe answer is the default. */
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -21801,3 +21801,15 @@ tr.sel .aprs-sym {
   gap: var(--space-2);
   margin-top: var(--space-4);
 }
+/* The affirmative button of a DESTRUCTIVE confirm (`danger: true`). Without this the class was
+   inert — there is no `.settings-save.danger` or bare `.danger` rule — so all eleven destructive
+   confirms painted as an ordinary accent save button, and the one visual cue that this button
+   deletes something was simply absent. Filled rather than outlined, following
+   `.logconfirm-log.danger`: it IS the primary action of its dialog, just a dangerous one. */
+.settings-save.danger {
+  background: var(--state-weak);
+  color: #fff;
+}
+.settings-save.danger:hover:not(:disabled) {
+  filter: brightness(1.06);
+}


### PR DESCRIPTION
## Summary

**On macOS, every confirmation in Nexus silently answers "no."**

Remove radio does nothing at all — no dialog, no error, no effect. So do Restore, the
working-frequency reset, deleting a QSO, deleting an SSTV image, clearing the channel list,
deleting a conversation, and both radio-switch guards.

WKWebView shows a JS confirm only if the host implements `runJavaScriptConfirmPanelWithMessage`.
**wry 0.55.1 implements exactly three `WKUIDelegate` methods** — `runOpenPanelWithParameters`,
`requestMediaCapturePermissionForOrigin`, `createWebViewWithConfiguration` — and that is not among
them. So `confirm()` returns `false` immediately, displaying nothing, and every guard written as

```ts
if (!window.confirm('…')) return
```

cancels silently.

**It is macOS-only.** `src/webview2` and `src/webkitgtk` contain no script-dialog handling at all,
so those fall through to the engines' own defaults, and both show dialogs. Checked in the wry
source rather than inferred from behaviour.

## Two symptoms that didn't look like this bug

**Restore appearing to do nothing.** There is a genuine persistence bug there too (#85) — but the
backend was never even reached, because the confirm cancelled first. Two independent faults on one
path, which is why fixing either alone changed nothing visible.

**"Cannot select any radio in the settings pane."** Both radio-switch paths are guarded by
`if (dirty && !confirm('Discard unsaved changes?')) return`. With a dead confirm that reads as *the
operator said no* — so with an unsaved form, every radio switch silently did nothing.

## The replacement

`confirmDialog()` is promise-based on the existing Radix `Dialog` primitive. It **fails closed**:
with no host mounted it resolves `false` and logs, because a missing dialog that answered *yes*
would turn this into silent data loss — strictly worse than the silence it replaces. That is the
first thing `confirm.test.tsx` pins.

## Two sites deliberately NOT converted

Both are transmit path, and both currently fail **safe**:

- `SetupHealth`'s *"Prove the transmit path?"* — keys the TX for ~2 s;
- `SstvView`'s **ISS 145.800 downlink** guard.

Converting them restores the intended ask-then-allow, but that **enables transmission where it is
presently blocked**. That is your call to make deliberately, not a side effect of a UI fix. Say the
word and I will send them as their own change.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench / hardware — macOS 26 on Apple Silicon, confirmed against the
  running app: Remove radio and Reset both did nothing before, both ask and work after.
- **Notes:** **3261 passed / 0 failed across 261 files**, `tsc -b` clean. No on-air validation
  applies.
- **Correction (2026-08-17).** An earlier version of this section said the existing suite "could
  never have caught this" because the tests that touch these paths "mock `window.confirm` to
  return `true`". That was wrong, and the reason is worse than the excuse: **nothing in the suite
  mocks `window.confirm` at all** — none of the twelve converted paths had ANY coverage, and a
  guard nothing exercises cannot fail whatever it returns. The same sentence was in
  `src/confirm.tsx`'s header and has been corrected there too. This PR now adds
  `SettingsPanel.removeradio.test.tsx`, which drives Remove radio end to end (asks / confirms and
  removes that radio / dismisses and keeps it) and fails if no host is rendered — the shape of
  test that would actually have caught the original bug.
- **Two `window.confirm` calls remain, deliberately** — SetupHealth's Prove TX and SstvView's ISS
  145.800 guard. Both are transmit-path, so converting them is a TX-behaviour change wanting
  sign-off rather than part of a UI pass. What they do on macOS meanwhile is now recorded in
  `confirm.tsx`: both read the inert `false` as "no", so each BLOCKS its action. Nothing keys,
  which is the safe direction — but Prove TX is a dead button there, and SSTV cannot be sent on
  145.800 at all. Happy to take these in a follow-up on your word.

## Checklist

- [x] `cargo test` passes on the workspace — no Rust change in this PR.
- [x] `cargo clippy --all-targets` is clean — no Rust change in this PR.
- [x] UI touched? Yes — `tsc -b` passes and the UI suite is green.
- [x] Docs updated where relevant — the reasoning is in `src/confirm.tsx`'s header.
- [x] **Validation honesty:** stated above.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.

