### PR TITLE
Make the watch_identity golden portable across architectures

### DIFF
--- a/crates/tempo-app/tests/fixtures/watch_identity_snapshot.json
+++ b/crates/tempo-app/tests/fixtures/watch_identity_snapshot.json
@@ -15,7 +15,7 @@
   "hunt": null,
   "link": {
     "dtSec": 0.04749727249145508,
-    "freqHz": 1499.9281005859375,
+    "freqHz": 1500,
     "quality": 1.0,
     "rv": -1,
     "snrDb": 72.0,
@@ -104,7 +104,7 @@
       "country": null,
       "directedToMe": false,
       "dtSec": 0.04749727249145508,
-      "freqHz": 1499.9281005859375,
+      "freqHz": 1500,
       "from": "N7GHI",
       "grid": "DM79",
       "gridRarity": null,

--- a/crates/tempo-app/tests/watch_identity.rs
+++ b/crates/tempo-app/tests/watch_identity.rs
@@ -126,6 +126,30 @@ fn normalize(v: &mut Value) {
                     || k.ends_with("Tick")
                 {
                     *val = Value::Null;
+                } else if k == "freqHz" {
+                    // ARCHITECTURE-DEPENDENT, so it cannot be pinned byte-exactly.
+                    //
+                    // This is the decoder's ESTIMATED frequency: an f32 out of an FFT and
+                    // interpolation chain. aarch64 contracts multiply-adds where x86-64 does not,
+                    // so the same input lands a fraction of a Hz apart on the two. Measured on a
+                    // clean checkout of this commit: 1499.9137 on aarch64-apple-darwin against the
+                    // committed 1499.9281 — 0.014 Hz, with every other field in the document byte
+                    // identical, decode text and roster attribution included. The signal is
+                    // synthesised at exactly 1500.0 Hz, so both are correct answers.
+                    //
+                    // Nulling it like the fields above would throw the check away; the frequency
+                    // the decoder reports IS receive output worth pinning. Round to whole Hz
+                    // instead: that absorbs the platform difference with ~35x margin while still
+                    // catching anything that would actually matter — a regression that moves this
+                    // lands on a different bin or fails to decode at all, never 0.014 Hz away.
+                    // Only the FLOAT estimate. The roster carries an integer freqHz of its own
+                    // (already rounded at the source), and turning that into 1500.0 would change
+                    // the document's shape for a field that never drifts.
+                    if val.is_f64() {
+                        if let Some(f) = val.as_f64() {
+                            *val = serde_json::json!(f.round() as i64);
+                        }
+                    }
                 } else {
                     normalize(val);
                 }


### PR DESCRIPTION
## Summary

`watch_identity_is_byte_identical_to_golden` **fails on a clean checkout of `main`** on
`aarch64-apple-darwin`. It is not a behaviour change — the entire drift is one field:

```
committed:   "freqHz": 1499.9281005859375
aarch64:     "freqHz": 1499.9136962890625
```

**0.014 Hz**, with every other field in the document byte-identical — decode text, roster
attribution and link state included. The signal is synthesised at exactly 1500.0 Hz, and both are
correct answers to it.

That field is the decoder's *estimate*: an `f32` out of an FFT and interpolation chain. aarch64
contracts multiply-adds where x86-64 does not, so identical input lands a fraction of a Hz apart on
the two. **Pinning it byte-exactly pins the architecture the golden was generated on** — so the
check can only ever pass there, and it fails for every macOS/ARM contributor building from source.
That is the path you said gets real maintenance, so it seemed worth fixing rather than working
around locally.

`normalize()` already exists for fields that can't be pinned (`nextSlotMs`, `clockOffsetMs`,
`*Tick`) — but it **nulls** them, and nulling this one would throw away a real piece of receive
output. Rounding to whole Hz absorbs the platform difference with ~35× margin while keeping the
check.

The roster's own integer `freqHz` is deliberately left alone: already rounded at the source, never
drifts, and coercing it would change the document's shape.

## Linked issue

Refs #6

## Validation

- **Validated against:** Bench — `aarch64-apple-darwin`, macOS 26, on a clean checkout of
  `4c4c52de` before any of my changes.
- **Notes:** Verified the drift is **deterministic** (identical MD5 across two regenerations, so
  not noise) and **isolated** (only those two lines change). The fix was checked in both
  directions, which matters more than that it passes: **a 1 Hz shift in the fixture still fails,
  and an altered decode string still fails** — only the sub-Hz float is tolerated. `tempo-app`
  658 + 1 + 4 passing. No on-air validation applies; this is a test-portability fix.

I could not verify the x86-64 side myself — I have no Linux host — so the claim about *which*
architecture drifts from which is inference from the contraction behaviour, not measurement. What
is measured is that this commit's committed fixture does not match what this commit produces on
aarch64.

## Checklist

- [x] `cargo test` passes on the workspace.
- [x] `cargo clippy --all-targets` is clean (no new warnings).
- [x] UI touched? No.
- [x] Docs updated where relevant — the reasoning is in the code comment.
- [x] **Validation honesty:** stated above, including what I could not verify.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.
