### PR TITLE
The macOS CI job's name still says macOS is unsupported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,15 +444,10 @@ jobs:
   # ship — which is exactly how the first run failed (`ld: library 'gfortran' not found`, after the
   # Fortran itself had built fine). Apple Silicon is also what most Mac operators are on.
   #
-  # ⚠️ UNPROVEN UNTIL IT FIRST RUNS, and said plainly rather than discovered. The step
-  # list mirrors `windows-cross` exactly (same node, same UI build, same AICW escape
-  # hatch, same cargo invocation), but no macOS runner was available to author it
-  # against. The likely first failure is libtempo's CMake step not finding Homebrew's
-  # gfortran/fftw/boost under the `gcc` formula's versioned binary names — that is a
-  # brew-prefix/CMAKE_Fortran_COMPILER fix in this job, not a source problem. Expect one
-  # or two iterations; do not let a red run here be read as "macOS is broken".
+  # (The "unproven until it first runs" caveat that stood here is retired: it has run many times,
+  # and the CMake/Homebrew failure it predicted was fixed rather than theoretical.)
   macos-check:
-    name: macOS compile check (not a shipped platform)
+    name: macOS compile check (fast link check; the shipping build is in release.yml)
     runs-on: macos-14
     steps:
       - name: Checkout


### PR DESCRIPTION
Replaces #109's sibling #113, which I closed — you had already done most of that PR, and better.
`f8dd2b9c` rewrote this job's header comment ("Since 1.5.0 macOS IS a supported platform", with the
entitlement gap dated and the 1.5.x/1.6.0 DMGs named). Two things survived it, and this is only those.

**1. The job's `name:` still says the opposite of the comment above it.**

```diff
-    name: macOS compile check (not a shipped platform)
+    name: macOS compile check (fast link check; the shipping build is in release.yml)
```

The header was corrected; the name was not. And the name is the string that actually gets read — it
appears in the checks list on every PR, and in any required-checks configuration. Renamed to say what
the job **is** rather than what the platform isn't, which is a reason that survives macOS becoming
supported: a fast link check on every push, where the shipping build runs on a release tag.

**2. The "UNPROVEN UNTIL IT FIRST RUNS" paragraph is retired.** It has run many times, and the
CMake/Homebrew failure it predicted was fixed rather than theoretical, so the caveat now only misleads
a reader into discounting a red run.

Nothing else — no step, runner, command or behaviour is touched. `ci.yml` parses, no duplicate keys
(checked with a loader that rejects them; pyyaml silently keeps the last one and GitHub does not),
8 jobs, name as shown.

⚠️ **This PR will show no checks until you approve the run.** A fork PR that touches
`.github/workflows/` needs a maintainer to allow CI — #113 sat at 0 check-runs for a day for exactly
that reason, which took me a while to work out.
