### PR TITLE
monitor: go silent while the operator is talking

### DIFF
--- a/crates/tempo-audio/src/backend.rs
+++ b/crates/tempo-audio/src/backend.rs
@@ -91,6 +91,14 @@ pub trait AudioBackend {
     fn set_monitor(&mut self, _enabled: bool, _device: &str, _level: f32) -> Result<(), String> {
         Ok(())
     }
+
+    /// Mute the headphone monitor for the duration of a transmission.
+    ///
+    /// The monitor plays what the capture callback hears, and while the rig is keyed that is not
+    /// the band — on many radios it is the rig's own MONI, arriving through the monitor ring and
+    /// therefore DELAYED. Delayed sidetone is hard to talk over. A no-op for backends with no
+    /// monitor.
+    fn set_monitor_tx_mute(&mut self, _muted: bool) {}
     /// Open (`Some(name)`) or close (`None`) a transient SECOND input stream capturing
     /// the operator's voice from a dedicated mic, used only while a recording is in
     /// progress — so "record a voice message" captures the mic, not the shared rig-codec

--- a/crates/tempo-audio/src/device.rs
+++ b/crates/tempo-audio/src/device.rs
@@ -770,6 +770,12 @@ impl CpalBackend {
         // STREAM (not in RxTap) so each open owns exactly one producer — see rxtap.rs.
         let tap_ring = Arc::new(SpscRing::new((in_rate as usize).max(12_000)));
         let mon_enabled = Arc::new(AtomicBool::new(false));
+        // MUTED WHILE KEYED. The monitor plays what the capture callback hears, and while the rig
+        // is transmitting that is not the band — it is whatever the codec emits during TX, which on
+        // many radios is their own MONI. Played back through this ring it arrives DELAYED, and
+        // delayed sidetone is genuinely hard to talk over. Separate from `mon_enabled` on purpose:
+        // that one is the operator's setting and must survive a transmission unchanged.
+        let mon_tx_mute = Arc::new(AtomicBool::new(false));
         let mon_level = Arc::new(AtomicU32::new(0.5f32.to_bits()));
 
         // ---- input: fold to mono f32 (dominant lane × RX gain) → in_ring (+ peak meter) ----
@@ -778,6 +784,7 @@ impl CpalBackend {
         let mon_ring_in = mon_ring.clone();
         let tap_ring_in = tap_ring.clone();
         let mon_enabled_in = mon_enabled.clone();
+        let mon_tx_mute_in = mon_tx_mute.clone();
         let rx_gain_cb = rx_gain.clone();
         let in_stream = match in_cfg.sample_format() {
             SampleFormat::F32 => in_dev.build_input_stream(
@@ -788,7 +795,8 @@ impl CpalBackend {
                     // push each mono sample into the wait-free monitor ring — it never
                     // blocks or allocates and drops on overflow, so the decode path
                     // (this same callback) is never stalled by monitoring.
-                    let monitoring = mon_enabled_in.load(Ordering::Relaxed);
+                    let monitoring = mon_enabled_in.load(Ordering::Relaxed)
+                        && !mon_tx_mute_in.load(Ordering::Relaxed);
                     let g = f32::from_bits(rx_gain_cb.load(Ordering::Relaxed));
                     let ch = in_ch.max(1);
                     let mut sum_sq = 0.0f32;
@@ -823,7 +831,8 @@ impl CpalBackend {
                 &in_cfg.config(),
                 move |data: &[i16], _: &cpal::InputCallbackInfo| {
                     let mut ring = in_ring_cb.lock().unwrap_or_else(|e| e.into_inner());
-                    let monitoring = mon_enabled_in.load(Ordering::Relaxed);
+                    let monitoring = mon_enabled_in.load(Ordering::Relaxed)
+                        && !mon_tx_mute_in.load(Ordering::Relaxed);
                     let g = f32::from_bits(rx_gain_cb.load(Ordering::Relaxed));
                     let ch = in_ch.max(1);
                     let mut sum_sq = 0.0f32;
@@ -855,7 +864,8 @@ impl CpalBackend {
                 &in_cfg.config(),
                 move |data: &[u8], _: &cpal::InputCallbackInfo| {
                     let mut ring = in_ring_cb.lock().unwrap_or_else(|e| e.into_inner());
-                    let monitoring = mon_enabled_in.load(Ordering::Relaxed);
+                    let monitoring = mon_enabled_in.load(Ordering::Relaxed)
+                        && !mon_tx_mute_in.load(Ordering::Relaxed);
                     let g = f32::from_bits(rx_gain_cb.load(Ordering::Relaxed));
                     let ch = in_ch.max(1);
                     let mut sum_sq = 0.0f32;
@@ -890,7 +900,8 @@ impl CpalBackend {
                 &in_cfg.config(),
                 move |data: &[i32], _: &cpal::InputCallbackInfo| {
                     let mut ring = in_ring_cb.lock().unwrap_or_else(|e| e.into_inner());
-                    let monitoring = mon_enabled_in.load(Ordering::Relaxed);
+                    let monitoring = mon_enabled_in.load(Ordering::Relaxed)
+                        && !mon_tx_mute_in.load(Ordering::Relaxed);
                     let g = f32::from_bits(rx_gain_cb.load(Ordering::Relaxed));
                     let ch = in_ch.max(1);
                     let mut sum_sq = 0.0f32;
@@ -1009,7 +1020,7 @@ impl CpalBackend {
             rx_level,
             rx_gain,
             tx_level,
-            monitor: Monitor::new(mon_ring, mon_enabled, mon_level, in_rate),
+            monitor: Monitor::new(mon_ring, mon_enabled, mon_tx_mute, mon_level, in_rate),
             spectrum_tap: tap_ring,
             in_rate,
             voice_mic: None,
@@ -1187,6 +1198,10 @@ impl AudioBackend for CpalBackend {
     /// restarts.
     fn set_monitor(&mut self, enabled: bool, device: &str, level: f32) -> Result<(), String> {
         self.monitor.apply(enabled, device, level)
+    }
+
+    fn set_monitor_tx_mute(&mut self, muted: bool) {
+        self.monitor.set_tx_mute(muted);
     }
 
     /// Open (`Some(name)`) or close (`None`) the transient voice-mic input stream. Opens

--- a/crates/tempo-audio/src/monitor.rs
+++ b/crates/tempo-audio/src/monitor.rs
@@ -433,34 +433,69 @@ mod device_monitor {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "device")]
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    #[cfg(feature = "device")]
+    use std::sync::Arc;
 
     /// A transmission must not be played back to the operator, and what was buffered before it
     /// must not surface afterwards.
     ///
-    /// The monitor plays what the capture callback hears. While the rig is keyed that is not the
-    /// band — on many radios it is the rig's own MONI — and it arrives through this ring, so it is
-    /// DELAYED. Delayed sidetone over your own voice is the specific complaint (operator,
-    /// 2026-08-22, which is what prompted this).
+    /// Drives the REAL thing — `Monitor::set_tx_mute` and the atomics the capture callback reads.
+    /// The first version of this test did not: it built a `SpscRing`, called `clear()` and checked
+    /// the ring was empty, which `SpscRing::clear` already has its own test for and which passes
+    /// with this whole feature deleted (kd9taw caught it on #158). A test that cannot fail when the
+    /// feature is removed is not evidence of the feature.
     ///
-    /// Two halves, and the second is the one worth a test: the gate closes, AND the ring is
-    /// cleared on the rising edge, so the seconds of band audio captured just before the key went
-    /// down do not play out as a burst of the past when the over ends.
+    /// `Monitor` needs no audio device to construct: `new` takes the shared `Arc`s and
+    /// `out_stream` starts `None`.
+    #[cfg(feature = "device")]
     #[test]
-    fn a_transmission_silences_the_monitor_and_discards_what_preceded_it() {
-        let ring = SpscRing::new(64);
+    fn muting_for_a_transmission_closes_the_gate_and_discards_the_audio_that_preceded_it() {
+        let ring = Arc::new(SpscRing::new(64));
+        let enabled = Arc::new(AtomicBool::new(true));
+        let tx_mute = Arc::new(AtomicBool::new(false));
+        let level = Arc::new(AtomicU32::new(0.5f32.to_bits()));
+        let mut m = Monitor::new(
+            ring.clone(),
+            enabled.clone(),
+            tx_mute.clone(),
+            level.clone(),
+            48_000,
+        );
+
         for _ in 0..16 {
-            assert!(ring.push(0.5), "fixture: band audio buffered before the over");
+            assert!(
+                ring.push(0.5),
+                "fixture: band audio buffered before the over"
+            );
         }
-        assert!(ring.len() > 0, "fixture: the ring holds pre-TX audio");
 
-        // The rising edge of a transmission: gate shut, and the past discarded.
-        ring.clear();
-        assert_eq!(ring.len(), 0, "what was captured before the over must not survive it");
-        assert!(ring.pop().is_none(), "and nothing is left to play out when the over ends");
+        // THE RISING EDGE. The gate the capture callback reads closes, and the audio captured
+        // before the key went down goes with it — otherwise it plays out as a burst of the past
+        // when the over ends, which is a stranger artefact than the one this fixes.
+        m.set_tx_mute(true);
+        assert!(tx_mute.load(Ordering::Relaxed), "the gate closed");
+        assert_eq!(ring.len(), 0, "and the pre-TX audio went with it");
 
-        // The ring is still usable afterwards — muting is not a teardown.
-        assert!(ring.push(0.25), "the monitor resumes after the over without a rebuild");
-        assert_eq!(ring.pop(), Some(0.25));
+        // EDGE-TRIGGERED, which is a claim the design makes and therefore has to be held to:
+        // muting again mid-over must not wipe anything a second time.
+        assert!(ring.push(0.25), "something arrives while still keyed");
+        m.set_tx_mute(true);
+        assert_eq!(ring.len(), 1, "muting again is not a second clear");
+
+        // AND THE OPERATOR'S OWN SETTING IS UNTOUCHED THROUGHOUT. This is the invariant the whole
+        // design rests on — the reason the mute is a second atomic rather than borrowing
+        // `enabled` — and nothing held us to it before.
+        m.set_tx_mute(false);
+        assert!(
+            !tx_mute.load(Ordering::Relaxed),
+            "the gate reopens when the over ends"
+        );
+        assert!(
+            enabled.load(Ordering::Relaxed),
+            "the operator's monitor setting survives a transmission unchanged"
+        );
     }
     use super::*;
 

--- a/crates/tempo-audio/src/monitor.rs
+++ b/crates/tempo-audio/src/monitor.rs
@@ -217,6 +217,11 @@ mod device_monitor {
         ring: Arc<SpscRing>,
         /// Gates the capture-callback push: cleared → the callback skips the ring.
         enabled: Arc<AtomicBool>,
+        /// Set while the rig is KEYED. The capture callback treats it as a second gate, so the
+        /// monitor goes silent for the duration of a transmission and the operator does not hear
+        /// the rig's own delayed MONI over their own voice. Deliberately NOT `enabled`: that is
+        /// the operator's setting and must come back unchanged when the over ends.
+        tx_mute: Arc<AtomicBool>,
         /// Playback level as `f32` bits, read live by the output callback.
         level_bits: Arc<AtomicU32>,
         /// The capture rate the ring is filled at (the monitor output opens here
@@ -233,12 +238,14 @@ mod device_monitor {
         pub fn new(
             ring: Arc<SpscRing>,
             enabled: Arc<AtomicBool>,
+            tx_mute: Arc<AtomicBool>,
             level_bits: Arc<AtomicU32>,
             in_rate: u32,
         ) -> Self {
             Self {
                 ring,
                 enabled,
+                tx_mute,
                 level_bits,
                 in_rate,
                 out_stream: None,
@@ -256,6 +263,19 @@ mod device_monitor {
         /// stream the backend owns inside ONE critical section
         /// (`AudioBackend::release_device`). Use [`Self::apply`] with `enabled: false`
         /// anywhere else; that one locks for you.
+        /// Mute or unmute for a transmission. Called from the radio loop on every keying change.
+        ///
+        /// On the RISING edge the ring is cleared as well as gated: whatever the capture pushed in
+        /// the moments before the key went down is band audio from before the over, and playing it
+        /// out when the over ends would be a small burst of the past. Cheap — `clear` is two atomic
+        /// stores — and it runs on the loop thread, never in an audio callback.
+        pub fn set_tx_mute(&mut self, muted: bool) {
+            let was = self.tx_mute.swap(muted, Ordering::Release);
+            if muted && !was {
+                self.ring.clear();
+            }
+        }
+
         pub fn release_locked(&mut self) {
             self.enabled.store(false, Ordering::Release);
             self.out_stream = None;
@@ -413,6 +433,35 @@ mod device_monitor {
 
 #[cfg(test)]
 mod tests {
+
+    /// A transmission must not be played back to the operator, and what was buffered before it
+    /// must not surface afterwards.
+    ///
+    /// The monitor plays what the capture callback hears. While the rig is keyed that is not the
+    /// band — on many radios it is the rig's own MONI — and it arrives through this ring, so it is
+    /// DELAYED. Delayed sidetone over your own voice is the specific complaint (operator,
+    /// 2026-08-22, which is what prompted this).
+    ///
+    /// Two halves, and the second is the one worth a test: the gate closes, AND the ring is
+    /// cleared on the rising edge, so the seconds of band audio captured just before the key went
+    /// down do not play out as a burst of the past when the over ends.
+    #[test]
+    fn a_transmission_silences_the_monitor_and_discards_what_preceded_it() {
+        let ring = SpscRing::new(64);
+        for _ in 0..16 {
+            assert!(ring.push(0.5), "fixture: band audio buffered before the over");
+        }
+        assert!(ring.len() > 0, "fixture: the ring holds pre-TX audio");
+
+        // The rising edge of a transmission: gate shut, and the past discarded.
+        ring.clear();
+        assert_eq!(ring.len(), 0, "what was captured before the over must not survive it");
+        assert!(ring.pop().is_none(), "and nothing is left to play out when the over ends");
+
+        // The ring is still usable afterwards — muting is not a teardown.
+        assert!(ring.push(0.25), "the monitor resumes after the over without a rebuild");
+        assert_eq!(ring.pop(), Some(0.25));
+    }
     use super::*;
 
     #[test]

--- a/crates/tempo-audio/src/service.rs
+++ b/crates/tempo-audio/src/service.rs
@@ -2410,6 +2410,9 @@ struct RadioLoop {
     /// change (used when the voice-mic notice cleared a line the monitor may
     /// still be entitled to — its guard/failure state gets re-surfaced).
     monitor_reapply: bool,
+    /// Last TX-mute state pushed to the audio backend, so the loop only speaks on a CHANGE.
+    /// `false` initially, which matches a monitor that starts unmuted.
+    monitor_tx_muted: bool,
     /// One-shot: force the RX-audio backend to rebuild on the next tick even if `audio_differs` is
     /// false. Set by a dual-radio handoff — the new radio's audio device MUST be (re)opened, and a
     /// radio whose audio is "system default" (empty) would otherwise compare equal to another empty
@@ -2779,6 +2782,7 @@ impl RadioLoop {
             voice_mic_open: false,
             voice_mic_failed: false,
             monitor_reapply: false,
+            monitor_tx_muted: false,
             force_audio_rebuild: false,
             audio_retry_at: None,
             audio_suspect: None,
@@ -4242,6 +4246,26 @@ impl RadioLoop {
                 }
                 if (want.rx_gain - self.applied.rx_gain).abs() > f32::EPSILON {
                     backend.set_rx_gain(want.rx_gain);
+                }
+            }
+
+            // MUTE THE MONITOR WHILE THE OPERATOR IS TALKING. Independent of the block below,
+            // which reacts to SETTINGS changes — this reacts to KEYING, and the two are unrelated
+            // events. Edge-triggered so the loop speaks to the backend once per transition rather
+            // than every tick.
+            //
+            // SCOPE, stated rather than implied: `manual_ptt` is the operator holding PTT (or the
+            // CAT broker holding it for them) — a PHONE over. It is the case this exists for,
+            // because that is when the rig's own delayed MONI lands on top of the voice the
+            // operator is still speaking. An FT slot, a CW over or an RTTY stream also key the rig
+            // and are NOT covered here; nobody is talking through those, and widening this to
+            // every transmission means finding a signal that covers them all, which is a larger
+            // change than the problem needs today.
+            {
+                let keyed = engine_lock(engine).manual_ptt();
+                if keyed != self.monitor_tx_muted {
+                    self.monitor_tx_muted = keyed;
+                    backend.set_monitor_tx_mute(keyed);
                 }
             }
 


### PR DESCRIPTION
The headphone monitor plays what the capture callback hears. While the rig is keyed that is not the band — on many radios it is the rig's own MONI — and it reaches the operator through the monitor ring, so it arrives **delayed**. Delayed sidetone over the voice you are still speaking is genuinely hard to talk through.

Found sideways. An operator asked whether "Enable monitor" would put his own voice back in his ears while transmitting (that misnaming is #156 / #157). It does not — but chasing the answer showed that during a phone over it plays something almost as unwelcome, and nothing in `monitor.rs` or its service wiring had any notion of keying at all.

### How

**A second atomic, not a borrowed one.** `mon_enabled` is the operator's setting and must come back unchanged when the over ends, so the mute is its own flag and the capture callback treats the two as an AND. Four capture sites — one per sample format — each gained one relaxed load, which costs nothing in a callback already doing per-sample work.

**The ring is cleared on the rising edge**, not merely gated: the seconds of band audio captured just before the key went down would otherwise play out as a burst of the past when the over ends. `clear` is two atomic stores and runs on the loop thread, never in an audio callback.

**Edge-triggered** — the loop speaks to the backend once per transition rather than every tick.

### Scope, stated rather than implied

The signal is `manual_ptt`: the operator holding PTT, or the CAT broker holding it for them. That is a **phone** over, which is the case this exists for, because that is when someone is talking.

An FT slot, a CW over or an RTTY stream also key the rig and are **not** covered here. Nobody is speaking through those, and covering them means finding a signal that spans every transmit path — a larger change than this problem needs, and one I would rather propose separately than smuggle in.

### Verification

622 `tempo-audio` with `device,serial`, 110 `src-tauri` with `radio`, `cargo fmt --all --check` clean on the pinned 1.93.1.

The new test pins both halves — the gate closing, and the pre-TX audio being discarded rather than surfacing afterwards — because the second is the one that would otherwise be noticed only on the air.

Independent of #157, which renames the operator-facing labels; this one changes behaviour and nothing else.
