### PR TITLE
test: the permission-cure assertion is per-OS, because the cure is

### DIFF
--- a/crates/tempo-audio/src/baud_ladder.rs
+++ b/crates/tempo-audio/src/baud_ladder.rs
@@ -1442,10 +1442,22 @@ mod tests {
             m.to_lowercase().contains("permission"),
             "the verdict must name the fault: {m}"
         );
-        #[cfg(unix)]
+        // THE CURE IS PER-OS, so the assertion has to be too — `open_failure_cure` already
+        // branches on `target_os`, and this gate did not. `#[cfg(unix)]` admits macOS, where the
+        // cure is not the dialout group at all but the driver's Privacy & Security approval, so
+        // this assertion failed on every Mac while passing on Linux and being skipped on Windows.
+        // Splitting it keeps the coverage rather than narrowing the gate and losing it: each
+        // platform now asserts the cure it actually ships, and each names the step people miss.
+        #[cfg(target_os = "linux")]
         assert!(
             m.contains("dialout") && m.to_lowercase().contains("log out"),
-            "on Unix the cure is the group AND the re-login, which is the step people miss: {m}"
+            "on Linux the cure is the group AND the re-login, which is the step people miss: {m}"
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            m.contains("Privacy & Security"),
+            "on macOS a serial refusal is a driver the system has not been allowed to load, and \
+             the cure is in Settings — the dialout group does not exist here: {m}"
         );
 
         // POSITIVE CONTROL — a genuinely HELD port must still get the other-program cure, or


### PR DESCRIPTION
`a_permission_refusal_names_the_permission_cure_not_the_other_program` (77eb9077) fails on macOS.

The assertion is gated `#[cfg(unix)]` and demands the cure name the `dialout` group and a re-login.
macOS **is** unix, so the gate admits it — but `open_failure_cure` already branches on `target_os`,
and on macOS a serial refusal is a driver the system has not been allowed to load. The cure there is
Settings » Privacy & Security, and the `dialout` group does not exist at all. So the test demanded
Linux wording from a platform that correctly ships different wording.

**The production code is right and is untouched.** Only the test's gate is wrong.

Split per `target_os` rather than narrowed to Linux, so macOS keeps coverage instead of losing it:
each platform asserts the cure it actually ships. Windows stays uncovered by this assertion, exactly
as before.

**Why CI did not catch it.** The Linux job passes because Linux is the platform the assertion was
written for; the Windows job passes because `cfg(unix)` excludes it. It only appears on a Mac —
which is the same blind spot you named on #109 yesterday: *"A green build here says nothing about
yours."*

**Verified both ways on an M-series Mac**, so neither arm passes vacuously:

- restore `#[cfg(unix)]` → the test fails again (the original defect reproduces)
- alter the macOS cure text in `open_failure_cure` → the new macOS assertion fails

```
cargo test -p tempo-audio --features device,serial   7 bins, 733 passed, 0 failed
cargo +1.93.1 fmt --all --check                              clean
```

One file, one hunk, no production change. Branched off `main` so it carries nothing else — it is
independent of #147.
