### PR TITLE
docs: add MACOS.md — the build guide LINUX.md and WINDOWS.md never had a sibling for

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ Outside the workspace:
   `tempofast_cabi.f90` is the C ABI; `libtempo/tempodeep/` is the TempoDeep mode; `mingw-w64.cmake`
   is the cross toolchain file.
 - `scripts/` — build and asset scripts (see below).
-- `WINDOWS.md` — the authoritative Windows build and setup guide.
+- `WINDOWS.md`, `LINUX.md`, `MACOS.md` — the authoritative per-platform build and
+  setup guides.
 
 ---
 
@@ -156,6 +157,22 @@ Windows is the primary target. Two supported paths, both documented fully in
 Supporting scripts: `scripts/fetch-hamlib.sh` (stages `rigctld` + DLLs as a
 Tauri bundle resource so the installer ships CAT control offline) and
 `scripts/gen-icons.py` (app icons).
+
+### macOS build
+
+Apple Silicon, documented fully in [`MACOS.md`](MACOS.md). Needs
+`brew install cmake ninja gcc fftw boost node` (`gcc` is what provides
+`gfortran`; macOS ships no system Fortran), rustup's default host toolchain, and
+`tauri-cli` v2 — then `cargo tauri build --features radio,custom-protocol
+--bundles app,dmg` from `src-tauri/`.
+
+> **Export `PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"` first.** Both the
+> `libtempo` CMake project and `tempo-fast-sys/build.rs` find FFTW through
+> `pkg-config`, and a MacPorts `pkg-config` earlier on `PATH` cannot see
+> Homebrew's `.pc` files — which fails as `No package 'fftw3f' found` on a
+> machine where FFTW is installed. `MACOS.md` also covers why the Fortran
+> runtimes are linked statically (a dynamically-linked `.app` is dead on arrival
+> on any Mac without your Homebrew tree) and why there is no universal binary.
 
 ---
 

--- a/MACOS.md
+++ b/MACOS.md
@@ -1,0 +1,210 @@
+# Building & running Nexus on macOS
+
+The counterpart to [LINUX.md](LINUX.md) and [WINDOWS.md](WINDOWS.md). macOS has been a shipped
+platform since 1.5.0 and [`docs/install.md`](docs/install.md) covers installing the signed,
+notarized `.dmg` — which is what most operators want. This page is for building it yourself, and
+it exists because until now the only description of how was `.github/workflows/release.yml`
+(reported in issue #123).
+
+Nexus's modem (`libtempo`) is **Fortran + C/C++ + FFTW**, built through CMake by
+`tempo-fast-sys`'s build script — the same **native** (host == target) path Linux uses. The Tauri
+v2 shell renders in the OS's own **WKWebView**, so unlike Windows there is no web runtime to
+install. Audio is **CoreAudio** via `cpal`, no extra libraries. CAT and PTT go through Hamlib's
+`rigctld`, which the bundle carries — see [Hamlib](#hamlib-is-not-in-the-repo-either) below,
+because on macOS nothing makes you stage it.
+
+## Apple Silicon
+
+The published `.dmg` is **arm64 only, deliberately**, and there is no universal binary. A
+universal build means building `libtempo` — Fortran, FFTW and Boost through CMake — twice and
+`lipo`-ing the results, and Homebrew's `gfortran` is single-arch: there is no x86_64 Fortran and
+FFTW toolchain on an Apple Silicon machine to build the other half with. Apple Silicon covers
+every Mac sold since 2020.
+
+Intel is a **source build**, and it works: nothing below is arm-specific, and
+`tempo-fast-sys/build.rs` asks the toolchain where its own libraries are rather than hardcoding a
+prefix, so it is correct on both `/opt/homebrew` and `/usr/local`. It is simply not a platform
+anyone ships binaries for. An Intel-built `.dmg` will not run on Apple Silicon.
+
+## What you need
+
+Xcode's Command Line Tools for `clang` and `ld`, then Homebrew:
+
+```sh
+xcode-select --install
+brew install cmake ninja gcc fftw boost node
+brew install libusb          # only if you will stage Hamlib for a bundle (see below)
+```
+
+Plus [rustup](https://rustup.rs) with the pinned toolchain — CI uses **1.93.1**, and matching it
+locally is what makes `cargo clippy` agree with CI — and the Tauri CLI:
+`cargo install tauri-cli --version "^2"`.
+
+Some of that is worth a word:
+
+- **`gcc` is what provides `gfortran`.** There is no standalone `gfortran` formula, and macOS
+  ships no system Fortran compiler at all.
+- **`fftw`** brings the single-precision `fftw3f` the modem needs, and — because the shipped app
+  links it statically — its `libfftw3f.a` as well. **`boost`** is for the header-only CRC-14 in
+  `crc14.cpp`.
+- **No WebView package**, unlike Windows' WebView2: WKWebView is part of macOS.
+- **No Hamlib package.** Unlike an older macOS build that expected `brew install hamlib`, the
+  bundle now carries its own `rigctld`, built from source by `scripts/fetch-hamlib-unix.sh` —
+  which is also why `libusb` appears above.
+
+There is no `--target` to add: the default rustup host toolchain
+(`aarch64-apple-darwin`, or `x86_64-apple-darwin` on Intel) links against the same `clang` and
+`gfortran` everything else here uses. There is no `-gnu`-versus-`-msvc` choice to get wrong.
+
+## The one trap that costs an afternoon: `PKG_CONFIG_PATH`
+
+**If MacPorts is installed, `/opt/local` comes first on `PATH` and its `pkg-config` cannot see
+Homebrew's `.pc` files at all.** The build then fails with what looks like a missing dependency
+on a machine where the dependency is plainly installed:
+
+```
+-- Found PkgConfig: /opt/local/bin/pkg-config (found version "0.29.2")
+-- Checking for module 'fftw3f'
+--   No package 'fftw3f' found
+CMake Error at .../FindPkgConfig.cmake:645 (message):
+  The following required packages were not found:
+   - fftw3f
+```
+
+Two things read `pkg-config` here, so the export fixes both: `libtempo`'s CMake project finds
+FFTW with it, and `tempo-fast-sys/build.rs` runs `pkg-config --libs-only-L fftw3f` to learn where
+to point the linker.
+
+```sh
+export PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"
+pkg-config --exists fftw3f && echo ok      # the check, before you build anything
+```
+
+A shell that never ran `brew shellenv` leaves `PKG_CONFIG_PATH` unset entirely and hits the same
+wall without MacPorts being involved. Note that MacPorts shadows **`cmake`** too — the error
+above came from MacPorts' CMake 3.31 on a machine that also had Homebrew's 4.3.1 — so if you are
+diagnosing something stranger, check `which -a cmake pkg-config` before anything else.
+
+## Build
+
+```sh
+npm --prefix ui ci                # NOT `npm install` — it rewrites package-lock.json
+npm --prefix ui run build         # tsc -b && vite build
+
+cargo build                       # workspace (modem, engine, net)
+cargo test --workspace            # headless: no sound card, no radio
+
+cd src-tauri && cargo tauri dev   --features radio                        # live radio loop
+cd src-tauri && cargo tauri build --features radio,custom-protocol \
+                                  --bundles app,dmg                       # the .app + .dmg
+```
+
+Artifacts land under `src-tauri/target/release/bundle/` — `Nexus.app` in `macos/`, the `.dmg` in
+`dmg/`. Without `--features radio` the app builds and runs the whole UI but does not key the
+radio, which is what you want for UI work.
+
+`cargo test --workspace` **does not cover `src-tauri`**: the desktop shell is a standalone crate
+with its own `[workspace]` (see [CONTRIBUTING.md](CONTRIBUTING.md)), so it is built and tested
+separately, with `--features radio`.
+
+Two things will stop a `cargo tauri build` that has otherwise succeeded:
+
+- **The updater payload.** `createUpdaterArtifacts` is on and the updater's *public* key is in
+  `tauri.conf.json`, so Tauri emits a self-update tarball and then fails signing it — the private
+  key is a CI secret. A build you are not going to publish has no use for a payload it cannot
+  sign; turn it off:
+  `cargo tauri build --features radio,custom-protocol --bundles app,dmg --config '{"bundle":{"createUpdaterArtifacts":false}}'`
+- **The DeepCW model.** `src-tauri/resources/deepcw/model.onnx` is gitignored (AGPL-3.0, © e04),
+  so a fresh clone or a git worktree does not have it, and `src-tauri/build.rs` fails a *release*
+  build rather than silently shipping an app with no AI CW decoder. Stage it (see
+  `src-tauri/resources/deepcw/README.md`) or set `NEXUS_ALLOW_MISSING_AICW=1` to say you meant it.
+
+## The Fortran runtimes are linked statically, and that is not a preference
+
+On macOS the modem links **`libgfortran.a`, `libquadmath.a` and `libfftw3f.a` statically**, plus
+GCC's **`libemutls_w.a`**. Only the OS's own `libc++` and `libSystem` are dynamic. This matters to
+anyone building a `.app` they intend to hand to somebody else, and it is invisible until they do:
+
+- A dynamically-linked build **links and runs perfectly on the machine that built it**, because
+  that machine has Homebrew's gcc. On any Mac that does not, it aborts at load with
+  `dyld: Library not loaded: /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib`. The
+  first macOS artifact ever built did exactly this and was caught by the release smoke job on a
+  clean runner, not by any build check.
+- `libemutls_w.a` is there because **static libgfortran on Darwin uses emulated TLS** and
+  `___emutls_get_address` lives in GCC's own archive — Apple's linker and compiler-rt provide no
+  such symbol. The first static link failed on precisely this. It also sits in gcc's *versioned*
+  subdirectory rather than beside the other two, so `build.rs` probes its full path separately.
+- **libstdc++ is deliberately absent.** The C++ objects in `libtempo` are compiled by AppleClang,
+  not `g++`, so linking GNU libstdc++ would be both wrong and another Homebrew dependency.
+
+None of this needs setting up — `tempo-fast-sys/build.rs` does it whenever the Cargo *target* is
+macOS. It is written down because the failure mode is a working build that is dead on arrival
+elsewhere. To check a binary you built:
+
+```sh
+otool -L path/to/Nexus.app/Contents/MacOS/Nexus | grep -i 'homebrew\|gfortran\|fftw'
+```
+
+Silence is the correct answer. (Confirm the check itself works by running it against something
+that *is* dynamically linked to Homebrew — `otool -L $(brew --prefix)/bin/rigctld` — otherwise a
+clean result proves nothing.)
+
+One consequence worth knowing: the linker search path `build.rs` emits runs through Homebrew's
+version-stable `current` symlink and is deliberately not canonicalized, so a `brew upgrade gcc`
+does not strand you on a stale versioned path.
+
+## Hamlib is not in the repo either
+
+`src-tauri/resources/hamlib/` holds only Hamlib's five tracked licence texts; the binaries are
+gitignored and staged by `scripts/fetch-hamlib-unix.sh`, which builds Hamlib 4.7.1 from source
+and sets the loader path so the staged programs find their own `libhamlib` inside the bundle.
+
+**On macOS nothing makes you run it.** `src-tauri/build.rs` has a bundled-Hamlib presence gate,
+but it is Windows-targets-only by design, and the Tauri bundle glob `resources/hamlib/*` still
+matches the licence texts — so a `cargo tauri build` produces a green `.app` containing a hamlib
+directory with no Hamlib in it. Every Hamlib-backed rig is then CAT-dead while a native CI-V
+Icom works perfectly, which is indistinguishable from a code regression. If you are building a
+bundle you will actually operate with, run it first:
+
+```sh
+bash scripts/fetch-hamlib-unix.sh     # idempotent; skips if already staged
+```
+
+## Gatekeeper: your own build will not open on a double-click
+
+A build you produce yourself is not signed with a Developer ID and not notarized, so Gatekeeper
+refuses it — "cannot be opened because the developer cannot be verified", or "is damaged and
+can't be opened" on some versions. That is expected for a source build, not a fault in the app.
+**Right-click (or Control-click) `Nexus.app` → Open**, then confirm; once per build.
+
+This is not advice to pass on to anyone else. It only makes sense for a build you compiled
+yourself and therefore trust, and the published `.dmg` needs none of it. A real signed build
+takes an Apple Developer ID, `codesign` and notarization through `notarytool`; Tauri v2 picks the
+credentials up from the environment, and `release.yml`'s `macos` job is the worked example —
+`APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` imported into an ephemeral keychain for
+signing, and an App Store Connect API key (`APPLE_API_KEY`, `APPLE_API_ISSUER`,
+`APPLE_API_KEY_PATH`) for notarization. Nothing in `tauri.conf.json` changes to support it;
+without those variables `cargo tauri build` still succeeds and simply produces the unsigned build
+described above.
+
+The release pipeline does not take a human's word for any of this: `smoke-macos` mounts the
+built `.dmg` on a runner that never saw the signing keychain and asks `spctl` — the authority
+Gatekeeper itself consults — for a verdict, then checks that the microphone entitlement is in
+the *signature* of the shipped app rather than merely in the repo.
+
+## Running it
+
+Full setup is in [`docs/install.md`](docs/install.md) and the manual; only the macOS-specific
+parts are here.
+
+- **Microphone permission.** First launch prompts for it — that is the rig's RX audio arriving
+  through a USB CODEC, which macOS classifies as a microphone. Dismiss it and Nexus hears
+  nothing; re-enable under System Settings → Privacy & Security → Microphone.
+- **Serial ports** appear as `/dev/tty.usbserial-*` or `/dev/cu.usbserial-*`, not `/dev/ttyUSB*`.
+  Some USB-serial bridges (notably CH340/CH341 and older Prolific parts) need the vendor's driver
+  before the port shows up at all.
+- **Settings live in `~/.config/tempo/`**, not `~/Library/Application Support`. Nexus resolves its
+  config directory from `XDG_CONFIG_HOME` (falling back to `$HOME/.config`) on every non-Windows
+  platform, macOS included. Worth knowing if you script backups or profile switching.
+- **Keep the clock accurate** — decoding is slot-timed. macOS uses network time by default; do
+  not turn it off.

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ cd ui && npm install && npm test        # UI suites (vitest)
 ```
 
 The modem is Fortran + C behind a Rust FFI, so the **GNU toolchain** is required. See
-**[Building from Source](docs/manual/Building-from-Source.md)**, [WINDOWS.md](WINDOWS.md) and [LINUX.md](LINUX.md).
+**[Building from Source](docs/manual/Building-from-Source.md)**, [WINDOWS.md](WINDOWS.md), [LINUX.md](LINUX.md) and [MACOS.md](MACOS.md).
 
 ## Documentation
 

--- a/docs/manual/Building-from-Source.md
+++ b/docs/manual/Building-from-Source.md
@@ -72,6 +72,32 @@ No MSYS2 needed; produces the same installer.
 
 ---
 
+## Path C — macOS (Apple Silicon)
+
+Produces `Nexus.app` and the `.dmg`. The full guide is [`MACOS.md`](../../MACOS.md); this is the short version.
+
+1. **Install the toolchain:**
+
+   ```bash
+   xcode-select --install
+   brew install cmake ninja gcc fftw boost node
+   ```
+
+   `gcc` is what provides `gfortran` — there is no standalone formula, and macOS ships no system Fortran compiler. Then rustup (the default host toolchain; no target to add) and `cargo install tauri-cli --version "^2"`.
+
+2. **Point `pkg-config` at Homebrew** — `export PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"`. Both the CMake project and `tempo-fast-sys/build.rs` find FFTW this way, and a MacPorts `pkg-config` earlier on `PATH` cannot see Homebrew's `.pc` files: the failure reads as `No package 'fftw3f' found` on a machine where FFTW is installed.
+
+3. **Build:**
+
+   ```bash
+   npm --prefix ui ci && npm --prefix ui run build
+   cd src-tauri && cargo tauri build --features radio,custom-protocol --bundles app,dmg
+   ```
+
+**Apple Silicon only, and there is no universal binary:** a universal build means building the Fortran/FFTW modem twice and `lipo`-ing it, and Homebrew's `gfortran` is single-arch. Intel is a source build that works but ships no binaries. The modem's Fortran runtimes (gfortran, quadmath, fftw3f, plus GCC's `libemutls_w.a`) are linked **statically** — a dynamically-linked `.app` runs on the machine that built it and dies at load on any Mac without your Homebrew tree. And a build you sign yourself is not notarized, so Gatekeeper blocks it on a double-click: right-click ▸ **Open** once. `MACOS.md` covers all three.
+
+---
+
 ## Headless modem / engine tests (any platform)
 
 You don't need WebView2 or a radio to run the test suite — just the native modem toolchain so `ft1-sys` can build `libtempo` via CMake.
@@ -109,4 +135,5 @@ The GUI is built with `--features radio,custom-protocol` (`radio` = `device` + `
 
 - [Architecture and Protocol](Architecture-and-Protocol.md) — the layer-by-layer design.
 - [`WINDOWS.md`](../../WINDOWS.md) — the full Windows build/setup reference.
+- [`MACOS.md`](../../MACOS.md) — the full macOS build reference.
 - [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — crate layout, code style, PR workflow.


### PR DESCRIPTION
## Summary

macOS has been a shipped platform since 1.5.0, and until now the only description of how to build
one was `release.yml`. This adds `MACOS.md` at the repo root beside `LINUX.md` and `WINDOWS.md`, in
the same shape and depth.

The two additions you asked for on the issue are the sections it is built around:

- **The Fortran runtimes are linked statically** (gfortran, quadmath, fftw3f, plus GCC's
  `libemutls_w.a`) — with *why* that is not a preference: a dynamic build links and runs perfectly
  on the machine that built it and dies at `dyld` on any Mac without Homebrew's gcc. The local
  builder gets a working app and never discovers it until they hand it to somebody else. Includes
  the `otool -L` check and its positive control.
- **Apple Silicon, and why there is no universal binary** — the Fortran/FFTW modem would need
  building twice and `lipo`-ing, and Homebrew's gfortran is single-arch.

Also documented, each traced to the code rather than to memory: the `PKG_CONFIG_PATH` trap (a
MacPorts `pkg-config` earlier on `PATH` cannot see Homebrew's `.pc` files, and it fails as
`No package 'fftw3f' found` on a machine where FFTW is plainly installed — it shadows `cmake` too);
the updater payload that fails a build which has otherwise succeeded; the DeepCW gate; and that
`scripts/fetch-hamlib-unix.sh` is not run for you on macOS, so a plain `cargo tauri build` yields a
green `.app` with no Hamlib in it.

Three small edits wire it in: README's build-docs line; `CONTRIBUTING.md`'s platform list plus a
`### macOS build` subsection beside the Windows one (it did not mention macOS once); and a
`Path C — macOS` in `docs/manual/Building-from-Source.md`, so it reaches the manual the website
syncs — that was your note about landing it in `docs/`. The authoritative guide sits at the root
because that is where its two siblings are; happy to `git mv` it entirely into `docs/` if you would
rather.

Per your 2026-08-28 comment, this is the docs half only — no `build-macos.sh`.

## Linked issue

Closes #123

## Checklist

- [x] `cargo test` passes on the workspace — unchanged; this PR touches no code.
- [x] `cargo clippy --all-targets` is clean — unchanged; no code touched.
- [x] UI touched? No.
- [x] Docs updated where relevant — this PR *is* the doc.
- [x] **Validation honesty:** stated below.

## Validation

- **Validated against:** bench hardware — Apple Silicon, macOS 26.6.2, Homebrew `/opt/homebrew`,
  with MacPorts also installed, which is what made the `PKG_CONFIG_PATH` trap reproducible rather
  than remembered.
- **Notes:** Verified by running — the `pkg-config`/CMake failure and its fix (the CMake error block
  quoted in the doc is real output, and the same build succeeds with the export); the modem building
  through `tempo-fast-sys`; and the static link, both in the build script's emitted directives and
  with `otool -L` on a linked binary, where only `/usr/lib/libc++.1.dylib` and
  `/usr/lib/libSystem.B.dylib` are dynamic — `otool -L $(brew --prefix)/bin/rigctld` was run as the
  positive control so that clean result means something. Every markdown link checked, also with a
  control. Transcribed rather than run: a full `cargo tauri build`, the Gatekeeper right-click ▸ Open
  path, and the exact updater signing message — its mechanism is verified from `tauri.conf.json`, so
  the doc describes the behaviour rather than quoting a string I did not see. Nothing on the air;
  this changes no code.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBejNMqPEQ97AUjhFU26km
