### PR TITLE
clippy: two macOS-only lints in device.rs, and why neither is fixed by deleting

### DIFF
--- a/crates/tempo-audio/src/device.rs
+++ b/crates/tempo-audio/src/device.rs
@@ -1171,6 +1171,10 @@ struct RxTaps {
 /// Linux only, deliberately: Windows (WASAPI) and macOS have no such report, and their
 /// shipped behaviour stays byte-identical rather than re-benched for a fix they don't need.
 fn capture_config(cfg: &cpal::SupportedStreamConfig) -> cpal::StreamConfig {
+    // `mut` is REQUIRED on Linux — the block below reassigns `out.buffer_size` — and unnecessary
+    // everywhere else, where that block is compiled out. Removing it would break Linux; this is
+    // the same `cfg_attr` shape this file already uses on `sized_capture_buffer` below.
+    #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
     let mut out = cfg.config();
     #[cfg(target_os = "linux")]
     {
@@ -2299,7 +2303,12 @@ mod tx_route_tests {
 #[cfg(test)]
 mod device_naming_tests {
     use super::{cpal_device_name, resolve_configured, NamedDevice};
-    use cpal::traits::{DeviceTrait, HostTrait};
+    use cpal::traits::HostTrait;
+    // `DeviceTrait` is used ONLY by the Linux-gated test below, so importing it unconditionally
+    // makes it unused on macOS and Windows — and `-D warnings` turns that into a build failure.
+    // Gated rather than `allow`ed: the import now exists exactly where it is used.
+    #[cfg(target_os = "linux")]
+    use cpal::traits::DeviceTrait;
 
     /// ⚠️ THE REGRESSION THIS MIGRATION NEARLY SHIPPED TO EVERY LINUX STATION.
     ///


### PR DESCRIPTION
## Summary

`cargo clippy -p tempo-audio --features device,serial --all-targets -- -D warnings` — the exact
command CI runs — fails on any Mac. Both lints are in platform-conditional code, so the Linux job
compiles a different branch and never sees them, and `-D warnings` turns each into a build failure
for anyone developing on macOS.

**`unused import: DeviceTrait`** in `device_naming_tests`. Only the `#[cfg(target_os = "linux")]`
test uses it — the ungated test beside it uses `host.input_devices()`, which is `HostTrait`. Gated
the import to Linux rather than `allow`ing it, so it exists exactly where it is used. I checked that
every `DeviceTrait` method call in that module falls inside the gated test, so the Linux build
cannot lose an import it needs.

**`variable does not need to be mutable`** in `capture_config`. This one is a trap worth naming: the
`mut` is REQUIRED on Linux — the `#[cfg(target_os = "linux")]` block below it reassigns
`out.buffer_size` — and unnecessary everywhere else. Deleting it compiles clean on a Mac and breaks
Linux. So `#[cfg_attr(not(target_os = "linux"), allow(unused_mut))]` instead, which is the same
shape this file already uses on `sized_capture_buffer` a few lines further down.

Same shape as #186: a platform gate that admits macOS while the thing behind it is only true
elsewhere, invisible to a CI that runs its checks on Linux.

## Linked issue

None — found while building on macOS.

## Checklist

- [x] `cargo test` passes on the workspace — `tempo-audio --features device,serial`: 7 binaries, 761 passed, 0 failed.
- [x] `cargo clippy --all-targets` is clean — `--workspace` exit 0, and the failing `tempo-audio --features device,serial` command goes 4 errors → 0.
- [x] UI touched? No.
- [x] Docs updated where relevant — n/a; the reasoning is in the code comments, where the next person to try deleting that `mut` will read it.
- [x] **Validation honesty:** stated below.

## Validation

- **Validated against:** an Apple Silicon Mac (macOS 26.6.2, Homebrew), which is where both lints
  appear.
- **Notes:** `cargo clippy -p tempo-audio --features device,serial --all-targets -- -D warnings`
  goes from 4 errors to 0. Each fix was then reverted SEPARATELY to confirm it is load-bearing
  rather than incidental — ungating the import brings back 2 errors, removing the `cfg_attr` brings
  back 3. `cargo +1.93.1 fmt --all --check` clean, `cargo clippy --workspace --all-targets -- -D
  warnings` clean.
  **The Linux side is reasoned, not run:** no Linux target is installed here, so I could not compile
  it. That is precisely why the argument above is about WHERE the symbols are used — every
  `DeviceTrait` call sits inside the Linux-gated test, and the `mut` is left intact on Linux by the
  `cfg_attr` — rather than a claim that a Linux build went green. Your CI settles that half.
  Nothing on the air; no behaviour changes on any platform.

## License & sign-off

- [x] My commits are signed off (DCO) and my contribution is GPL-3.0-or-later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBejNMqPEQ97AUjhFU26km
